### PR TITLE
Add Targeting Rules Page and Backend Logic

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -49,6 +49,7 @@ jobs:
           dir ./nupkgs
 
       - name: Publish to NuGet
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
         run: |
@@ -58,6 +59,7 @@ jobs:
           }
 
       - name: Create GitHub Release
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         id: create_release
         uses: actions/create-release@v1
         env:
@@ -70,6 +72,7 @@ jobs:
           prerelease: false
 
       - name: Upload Release Assets
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
           $release_id = "${{ steps.create_release.outputs.id }}"
           Get-ChildItem ./nupkgs/*.nupkg | ForEach-Object {

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Tests are also run automatically in CI before NuGet deployment.
 - Persistent storage with EF Core (supports PostgreSQL and SQL Server)
 - Percentage-based rollout support
 - User-specific feature flag evaluation
+- **Advanced Targeting Rules Engine** for sophisticated user targeting
 - Embedded dashboard for managing feature flags
 - Secure dashboard access with authentication
 - Feature usage analytics and tracking
@@ -126,6 +127,71 @@ public class HomeController : Controller
 }
 ```
 
+### Advanced Targeting with User Attributes
+
+ToggleNet includes a powerful targeting rules engine that allows you to target users based on custom attributes, not just percentage rollouts.
+
+```csharp
+public class HomeController : Controller
+{
+    private readonly FeatureFlagManager _featureFlagManager;
+
+    public HomeController(FeatureFlagManager featureFlagManager)
+    {
+        _featureFlagManager = featureFlagManager;
+    }
+
+    public async Task<IActionResult> Index()
+    {
+        // Create user context with custom attributes
+        var userContext = new UserContext
+        {
+            UserId = "user123",
+            Attributes = new Dictionary<string, object>
+            {
+                ["country"] = "US",
+                ["userType"] = "premium",
+                ["age"] = 25,
+                ["deviceType"] = "mobile",
+                ["appVersion"] = "2.1.0",
+                ["plan"] = "enterprise"
+            }
+        };
+
+        // Check feature with targeting rules
+        bool isFeatureEnabled = await _featureFlagManager.IsEnabledAsync("advanced-analytics", userContext);
+        
+        // Or use the simplified overload
+        var userAttributes = new Dictionary<string, object>
+        {
+            ["country"] = "CA",
+            ["plan"] = "enterprise"
+        };
+        bool isEnabled = await _featureFlagManager.IsEnabledAsync("enterprise-features", "user456", userAttributes);
+        
+        return View();
+    }
+}
+```
+
+#### Targeting Rule Operators
+
+The targeting rules engine supports various operators for sophisticated targeting:
+
+- **String Operations**: `Equals`, `EqualsIgnoreCase`, `NotEquals`, `Contains`, `StartsWith`, `EndsWith`
+- **List Operations**: `In`, `NotIn` (supports JSON arrays or comma-separated values)
+- **Numeric Operations**: `GreaterThan`, `GreaterThanOrEqual`, `LessThan`, `LessThanOrEqual`
+- **Date Operations**: `Before`, `After`
+- **Version Operations**: `VersionGreaterThan`, `VersionLessThan` (semantic versioning)
+- **Pattern Matching**: `Regex`
+
+#### Rule Groups and Logic
+
+- **Rule Groups**: Combine multiple rules with `AND` or `OR` logic
+- **Priority**: Rules and rule groups are evaluated in priority order
+- **Fallback**: If no targeting rules match, falls back to percentage rollout
+- **Flexible Rollout**: Each rule group can have its own rollout percentage
+
 ### Analytics and Usage Tracking
 
 ToggleNet includes built-in feature usage analytics to help you understand how your features are being used.
@@ -189,6 +255,12 @@ app.UseToggleNetDashboard("/my-feature-flags");
 
 The dashboard provides multiple pages:
 * **Dashboard Home**: Manage and configure feature flags
+* **Targeting Rules**: Advanced configuration interface for targeting rules
+  * Visual rule builder interface
+  * Real-time rule testing with sample user data
+  * Support for complex rule groups with AND/OR logic
+  * Priority-based rule ordering with numeric values
+  * Per-rule group rollout percentages
 * **Analytics**: View usage statistics, trends, and individual usage events
   * Filter by time period (7, 30, or 90 days)
   * View unique user counts and total usage metrics
@@ -220,6 +292,67 @@ services.AddToggleNetDashboard(
 ## Sample Application
 
 Check out the `samples/SampleWebApp` project for a complete example of how to use ToggleNet in an ASP.NET Core application.
+
+### Targeting Rules Examples
+
+The sample application includes a `TargetingExampleController` that demonstrates various targeting scenarios:
+
+- **Basic targeting** with simple user attributes
+- **Complex targeting** with multiple user attributes and business logic
+- **Mobile-specific features** based on device type and OS version
+- **Beta testing programs** with version-specific targeting
+- **Regional compliance** features based on geographic location
+
+## Recent Updates - Targeting Rules Engine
+
+ToggleNet now includes a powerful **Targeting Rules Engine** that provides sophisticated user targeting capabilities beyond simple percentage rollouts:
+
+### Key Features Added:
+- **User Context System**: Rich user attribute support for targeting decisions
+- **Flexible Rule Operations**: 15+ operators including string, numeric, date, and version comparisons
+- **Rule Groups**: Combine multiple rules with AND/OR logic
+- **Priority-based Evaluation**: Control rule evaluation order with priorities
+- **Per-Rule Rollouts**: Each rule group can have its own rollout percentage
+- **Database Support**: Full Entity Framework Core integration
+- **Backward Compatibility**: Existing percentage-based flags continue to work
+
+### Quick Start with Targeting Rules:
+
+```csharp
+// Create user context with targeting attributes
+var userContext = new UserContext
+{
+    UserId = "user123",
+    Attributes = new Dictionary<string, object>
+    {
+        ["country"] = "US",
+        ["plan"] = "enterprise",
+        ["appVersion"] = "2.1.0"
+    }
+};
+
+// Check feature with targeting rules
+bool isEnabled = await _featureFlagManager.IsEnabledAsync("premium-features", userContext);
+```
+
+### Targeting Rules Dashboard:
+
+The new Targeting Rules dashboard (`/feature-flags/targeting-rules`) provides a user-friendly interface for configuring complex targeting scenarios:
+
+- **Visual Rule Builder**: Intuitive interface for creating targeting rules without code
+- **Rule Groups**: Organize related rules and set logical operators (AND/OR)
+- **Live Testing**: Test your targeting rules with sample user data before deployment
+- **Rule Priorities**: Control evaluation order with numeric priority values
+- **Flexible Rollouts**: Set different rollout percentages for each rule group
+- **Common Attributes**: Pre-populated suggestions for common user attributes like country, plan, device type, etc.
+
+Example targeting scenarios you can configure through the dashboard:
+- **Premium Features**: Target users with `plan = "enterprise"` AND `country IN ["US", "CA"]`
+- **Beta Features**: Target users with `betaTester = true` OR `appVersion >= "2.0.0"`
+- **Regional Features**: Target users with `country = "US"` with 50% rollout
+- **Device-Specific**: Target users with `deviceType = "mobile"` AND `osVersion >= "iOS 15"`
+
+This implementation provides enterprise-grade feature flag management with the flexibility to target users based on any combination of attributes while maintaining high performance and reliability.
 
 ## Database Setup
 

--- a/samples/SampleWebApp/Controllers/TargetingExampleController.cs
+++ b/samples/SampleWebApp/Controllers/TargetingExampleController.cs
@@ -1,0 +1,381 @@
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using ToggleNet.Core;
+using ToggleNet.Core.Entities;
+using SampleWebApp.Models;
+
+namespace SampleWebApp.Controllers
+{
+    public class TargetingExampleController : Controller
+    {
+        private readonly FeatureFlagManager _featureFlagManager;
+
+        public TargetingExampleController(FeatureFlagManager featureFlagManager)
+        {
+            _featureFlagManager = featureFlagManager;
+        }
+
+        public async Task<IActionResult> Index(string format = null)
+        {
+            // Example 1: Simple user context
+            var basicUserContext = new UserContext
+            {
+                UserId = "user123",
+                Attributes = new Dictionary<string, object>
+                {
+                    ["country"] = "US",
+                    ["userType"] = "premium"
+                }
+            };
+
+            var isBasicFeatureEnabled = await _featureFlagManager.IsEnabledAsync("basic-targeting", basicUserContext);
+
+            // Example 2: Complex user context with multiple attributes
+            var complexUserContext = new UserContext
+            {
+                UserId = "enterprise_user_456",
+                Attributes = new Dictionary<string, object>
+                {
+                    ["country"] = "CA",
+                    ["plan"] = "enterprise",
+                    ["companySize"] = 1500,
+                    ["industry"] = "technology",
+                    ["appVersion"] = "3.2.1",
+                    ["registrationDate"] = DateTime.Parse("2022-06-15"),
+                    ["betaTester"] = true,
+                    ["deviceType"] = "desktop",
+                    ["email"] = "user@company.com"
+                }
+            };
+
+            var isAdvancedFeatureEnabled = await _featureFlagManager.IsEnabledAsync("advanced-analytics", complexUserContext);
+
+            // Example 3: Using the simplified overload
+            var mobileUserAttributes = new Dictionary<string, object>
+            {
+                ["deviceType"] = "mobile",
+                ["osVersion"] = "iOS 17.0",
+                ["region"] = "north-america"
+            };
+
+            var isMobileFeatureEnabled = await _featureFlagManager.IsEnabledAsync("mobile-optimization", "mobile_user_789", mobileUserAttributes);
+
+            // Example 4: Multiple feature checks for different scenarios
+            var results = new Dictionary<string, object>
+            {
+                ["BasicTargeting"] = isBasicFeatureEnabled,
+                ["AdvancedAnalytics"] = isAdvancedFeatureEnabled,
+                ["MobileOptimization"] = isMobileFeatureEnabled,
+                
+                // Additional examples
+                ["BetaFeatures"] = await CheckBetaFeatures(complexUserContext),
+                ["RegionalFeatures"] = await CheckRegionalFeatures(basicUserContext),
+                ["VersionSpecificFeatures"] = await CheckVersionSpecificFeatures(complexUserContext),
+                
+                // Show user contexts for reference
+                ["UserContexts"] = new
+                {
+                    Basic = basicUserContext,
+                    Complex = complexUserContext,
+                    Mobile = new { UserId = "mobile_user_789", Attributes = mobileUserAttributes }
+                }
+            };
+
+            // Return JSON if requested, otherwise return view
+            if (format == "json")
+            {
+                return Json(results);
+            }
+
+            return View(results);
+        }
+
+        private async Task<bool> CheckBetaFeatures(UserContext userContext)
+        {
+            // This would check against a feature flag configured with targeting rules like:
+            // Rule 1: betaTester = true AND appVersion > "3.0.0"
+            // Rule 2: plan = "enterprise" AND companySize > 1000
+            return await _featureFlagManager.IsEnabledAsync("beta-features", userContext);
+        }
+
+        private async Task<bool> CheckRegionalFeatures(UserContext userContext)
+        {
+            // This would check against targeting rules like:
+            // Rule: country IN ["US", "CA", "UK"]
+            return await _featureFlagManager.IsEnabledAsync("regional-compliance", userContext);
+        }
+
+        private async Task<bool> CheckVersionSpecificFeatures(UserContext userContext)
+        {
+            // This would check against targeting rules like:
+            // Rule: appVersion >= "3.2.0" AND deviceType = "desktop"
+            return await _featureFlagManager.IsEnabledAsync("version-specific-ui", userContext);
+        }
+
+        [HttpGet]
+        public IActionResult ExampleRulesConfiguration()
+        {
+            // This demonstrates how targeting rules would be configured
+            // (in practice, this would be done through the dashboard UI)
+            
+            var exampleFeatureFlag = new FeatureFlag
+            {
+                Id = Guid.NewGuid(),
+                Name = "advanced-analytics",
+                Description = "Advanced analytics dashboard with sophisticated targeting",
+                IsEnabled = true,
+                Environment = "Production",
+                UseTargetingRules = true,
+                RolloutPercentage = 5, // Fallback percentage
+                TargetingRuleGroups = new List<TargetingRuleGroup>
+                {
+                    // Rule Group 1: Enterprise customers in North America
+                    new TargetingRuleGroup
+                    {
+                        Id = Guid.NewGuid(),
+                        Name = "Enterprise North America",
+                        LogicalOperator = LogicalOperator.And,
+                        Priority = 1,
+                        RolloutPercentage = 100,
+                        Rules = new List<TargetingRule>
+                        {
+                            new TargetingRule
+                            {
+                                Name = "Enterprise Plan",
+                                Attribute = "plan",
+                                Operator = TargetingOperator.EqualsIgnoreCase,
+                                Value = "enterprise"
+                            },
+                            new TargetingRule
+                            {
+                                Name = "North America",
+                                Attribute = "country",
+                                Operator = TargetingOperator.In,
+                                Value = "[\"US\", \"CA\"]"
+                            },
+                            new TargetingRule
+                            {
+                                Name = "Large Company",
+                                Attribute = "companySize",
+                                Operator = TargetingOperator.GreaterThan,
+                                Value = "500"
+                            }
+                        }
+                    },
+                    
+                    // Rule Group 2: Beta testers with modern app versions
+                    new TargetingRuleGroup
+                    {
+                        Id = Guid.NewGuid(),
+                        Name = "Beta Testers",
+                        LogicalOperator = LogicalOperator.And,
+                        Priority = 2,
+                        RolloutPercentage = 75, // Only 75% of matching users
+                        Rules = new List<TargetingRule>
+                        {
+                            new TargetingRule
+                            {
+                                Name = "Beta Tester",
+                                Attribute = "betaTester",
+                                Operator = TargetingOperator.Equals,
+                                Value = "true"
+                            },
+                            new TargetingRule
+                            {
+                                Name = "Modern App Version",
+                                Attribute = "appVersion",
+                                Operator = TargetingOperator.VersionGreaterThan,
+                                Value = "3.0.0"
+                            }
+                        }
+                    },
+                    
+                    // Rule Group 3: Tech industry OR early adopters
+                    new TargetingRuleGroup
+                    {
+                        Id = Guid.NewGuid(),
+                        Name = "Tech Industry or Early Adopters",
+                        LogicalOperator = LogicalOperator.Or,
+                        Priority = 3,
+                        RolloutPercentage = 50,
+                        Rules = new List<TargetingRule>
+                        {
+                            new TargetingRule
+                            {
+                                Name = "Technology Industry",
+                                Attribute = "industry",
+                                Operator = TargetingOperator.EqualsIgnoreCase,
+                                Value = "technology"
+                            },
+                            new TargetingRule
+                            {
+                                Name = "Early Registration",
+                                Attribute = "registrationDate",
+                                Operator = TargetingOperator.Before,
+                                Value = "2023-01-01"
+                            }
+                        }
+                    }
+                }
+            };
+
+            return Json(exampleFeatureFlag);
+        }
+
+        [HttpGet]
+        public IActionResult Dashboard()
+        {
+            // This action demonstrates how to integrate with the targeting rules dashboard
+            var dashboardInfo = new DashboardGuideViewModel
+            {
+                Message = "Use the ToggleNet Dashboard to configure targeting rules visually",
+                DashboardUrl = "/feature-flags",
+                TargetingRulesUrl = "/feature-flags/targeting-rules",
+                AnalyticsUrl = "/feature-flags/analytics",
+                Instructions = new List<string>
+                {
+                    "Navigate to /feature-flags to access the main dashboard",
+                    "Create feature flags or select existing ones",
+                    "Go to /feature-flags/targeting-rules to configure targeting rules visually",
+                    "Use the rule builder to create complex targeting scenarios",
+                    "Test your rules with sample user data before saving",
+                    "Monitor usage in /feature-flags/analytics"
+                },
+                ExampleTargetingScenarios = new List<ExampleTargetingScenario>
+                {
+                    new ExampleTargetingScenario
+                    {
+                        Name = "Premium Features",
+                        Description = "Target enterprise customers in specific regions",
+                        RuleExample = "plan = 'enterprise' AND country IN ['US', 'CA'] AND companySize > 500"
+                    },
+                    new ExampleTargetingScenario
+                    {
+                        Name = "Beta Features",
+                        Description = "Target beta testers with modern app versions",
+                        RuleExample = "betaTester = true AND appVersion >= '3.0.0'"
+                    },
+                    new ExampleTargetingScenario
+                    {
+                        Name = "Mobile Features",
+                        Description = "Target mobile users with specific OS versions",
+                        RuleExample = "deviceType = 'mobile' AND osVersion >= 'iOS 15.0'"
+                    },
+                    new ExampleTargetingScenario
+                    {
+                        Name = "Regional Compliance",
+                        Description = "Target users in specific countries with different rollout rates",
+                        RuleExample = "country = 'US' (100% rollout) OR country = 'EU' (50% rollout)"
+                    }
+                }
+            };
+
+            return View(dashboardInfo);
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> TestUserScenarios()
+        {
+            // This demonstrates various user scenarios for testing targeting rules
+            var testScenarios = new[]
+            {
+                new {
+                    Name = "Enterprise User - US",
+                    UserContext = new UserContext
+                    {
+                        UserId = "ent_user_001",
+                        Attributes = new Dictionary<string, object>
+                        {
+                            ["country"] = "US",
+                            ["plan"] = "enterprise",
+                            ["companySize"] = 2500,
+                            ["industry"] = "finance",
+                            ["appVersion"] = "3.2.5",
+                            ["deviceType"] = "desktop",
+                            ["betaTester"] = false
+                        }
+                    }
+                },
+                new {
+                    Name = "Beta Tester - Mobile",
+                    UserContext = new UserContext
+                    {
+                        UserId = "beta_user_002",
+                        Attributes = new Dictionary<string, object>
+                        {
+                            ["country"] = "CA",
+                            ["plan"] = "professional",
+                            ["companySize"] = 150,
+                            ["industry"] = "technology",
+                            ["appVersion"] = "3.3.0-beta",
+                            ["deviceType"] = "mobile",
+                            ["osVersion"] = "iOS 17.1",
+                            ["betaTester"] = true
+                        }
+                    }
+                },
+                new {
+                    Name = "Standard User - EU",
+                    UserContext = new UserContext
+                    {
+                        UserId = "std_user_003",
+                        Attributes = new Dictionary<string, object>
+                        {
+                            ["country"] = "DE",
+                            ["plan"] = "standard",
+                            ["companySize"] = 25,
+                            ["industry"] = "marketing",
+                            ["appVersion"] = "3.1.8",
+                            ["deviceType"] = "desktop",
+                            ["betaTester"] = false,
+                            ["registrationDate"] = "2023-08-15"
+                        }
+                    }
+                }
+            };
+
+            var results = new List<TestScenario>();
+
+            foreach (var scenario in testScenarios)
+            {
+                var featureResults = new Dictionary<string, bool>
+                {
+                    ["basic-targeting"] = await _featureFlagManager.IsEnabledAsync("basic-targeting", scenario.UserContext),
+                    ["advanced-analytics"] = await _featureFlagManager.IsEnabledAsync("advanced-analytics", scenario.UserContext),
+                    ["mobile-optimization"] = await _featureFlagManager.IsEnabledAsync("mobile-optimization", scenario.UserContext),
+                    ["beta-features"] = await _featureFlagManager.IsEnabledAsync("beta-features", scenario.UserContext),
+                    ["regional-compliance"] = await _featureFlagManager.IsEnabledAsync("regional-compliance", scenario.UserContext)
+                };
+
+                results.Add(new TestScenario
+                {
+                    Name = scenario.Name,
+                    UserContext = new UserContextInfo
+                    {
+                        UserId = scenario.UserContext.UserId,
+                        Attributes = scenario.UserContext.Attributes
+                    },
+                    FeatureResults = featureResults
+                });
+            }
+
+            var viewModel = new TestUserScenariosViewModel
+            {
+                Message = "These scenarios can be used to test targeting rules in the dashboard",
+                TestScenarios = results,
+                Instructions = new List<string>
+                {
+                    "Copy any of these user contexts to test in the targeting rules dashboard",
+                    "Navigate to /feature-flags/targeting-rules",
+                    "Select a feature flag and configure targeting rules",
+                    "Use the 'Test Rules' functionality with the above user data",
+                    "Observe how different user attributes affect feature flag evaluation"
+                }
+            };
+
+            return View(viewModel);
+        }
+    }
+}

--- a/samples/SampleWebApp/Models/TargetingExampleViewModels.cs
+++ b/samples/SampleWebApp/Models/TargetingExampleViewModels.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+
+namespace SampleWebApp.Models
+{
+    public class DashboardGuideViewModel
+    {
+        public string Message { get; set; } = string.Empty;
+        public string DashboardUrl { get; set; } = string.Empty;
+        public string TargetingRulesUrl { get; set; } = string.Empty;
+        public string AnalyticsUrl { get; set; } = string.Empty;
+        public List<string> Instructions { get; set; } = new();
+        public List<ExampleTargetingScenario> ExampleTargetingScenarios { get; set; } = new();
+    }
+
+    public class ExampleTargetingScenario
+    {
+        public string Name { get; set; } = string.Empty;
+        public string Description { get; set; } = string.Empty;
+        public string RuleExample { get; set; } = string.Empty;
+    }
+
+    public class TestUserScenariosViewModel
+    {
+        public string Message { get; set; } = string.Empty;
+        public List<string> Instructions { get; set; } = new();
+        public List<TestScenario> TestScenarios { get; set; } = new();
+    }
+
+    public class TestScenario
+    {
+        public string Name { get; set; } = string.Empty;
+        public UserContextInfo UserContext { get; set; } = new();
+        public Dictionary<string, bool> FeatureResults { get; set; } = new();
+    }
+
+    public class UserContextInfo
+    {
+        public string UserId { get; set; } = string.Empty;
+        public Dictionary<string, object> Attributes { get; set; } = new();
+    }
+}

--- a/samples/SampleWebApp/TARGETING_EXAMPLES.md
+++ b/samples/SampleWebApp/TARGETING_EXAMPLES.md
@@ -1,0 +1,108 @@
+# ToggleNet Targeting Rules Examples
+
+This sample application demonstrates how to use ToggleNet's advanced targeting rules functionality.
+
+## Getting Started
+
+1. **Run the Application**: Start the sample web app
+2. **Access the Dashboard**: Navigate to `/feature-flags` to manage feature flags
+3. **Configure Targeting Rules**: Go to `/feature-flags/targeting-rules` to set up advanced targeting
+
+## Example Endpoints
+
+### `/TargetingExample`
+Returns JSON showing how different user contexts are evaluated against targeting rules:
+- Basic user context (country, userType)
+- Complex enterprise user context (plan, companySize, industry, etc.)
+- Mobile user context (deviceType, osVersion, region)
+
+### `/TargetingExample/Dashboard`
+Provides information about using the targeting rules dashboard interface, including:
+- Dashboard URLs and navigation
+- Step-by-step instructions
+- Example targeting scenarios
+
+### `/TargetingExample/TestUserScenarios`
+Returns pre-built user scenarios that you can use to test targeting rules:
+- Enterprise User (US-based, large company)
+- Beta Tester (Mobile user with latest app version)
+- Standard User (EU-based, small company)
+
+### `/TargetingExample/ExampleRulesConfiguration`
+Shows how targeting rules would be configured programmatically (for reference - use the dashboard UI instead).
+
+## Common Targeting Scenarios
+
+### 1. Enterprise Features
+Target high-value customers:
+```
+plan = "enterprise" AND 
+country IN ["US", "CA"] AND 
+companySize > 500
+```
+
+### 2. Beta Testing Program
+Target beta testers with modern app versions:
+```
+betaTester = true AND 
+appVersion >= "3.0.0"
+```
+
+### 3. Mobile-Specific Features
+Target mobile users with compatible OS versions:
+```
+deviceType = "mobile" AND 
+osVersion >= "iOS 15.0"
+```
+
+### 4. Regional Compliance
+Different rollout rates by region:
+```
+Rule Group 1: country = "US" (100% rollout)
+Rule Group 2: country IN ["CA", "UK"] (75% rollout)
+Rule Group 3: country IN ["DE", "FR"] (50% rollout)
+```
+
+## User Attributes Reference
+
+The sample app demonstrates these common user attributes:
+
+| Attribute | Type | Example Values |
+|-----------|------|----------------|
+| `country` | String | "US", "CA", "UK", "DE" |
+| `plan` | String | "free", "professional", "enterprise" |
+| `companySize` | Number | 25, 150, 2500 |
+| `industry` | String | "technology", "finance", "marketing" |
+| `appVersion` | String | "3.1.8", "3.2.5", "3.3.0-beta" |
+| `deviceType` | String | "mobile", "desktop", "tablet" |
+| `osVersion` | String | "iOS 17.1", "Android 13", "Windows 11" |
+| `betaTester` | Boolean | true, false |
+| `registrationDate` | Date | "2023-08-15" |
+| `userType` | String | "free", "premium", "admin" |
+
+## Testing Your Rules
+
+1. **Use the Dashboard**: Navigate to `/feature-flags/targeting-rules`
+2. **Select a Feature Flag**: Choose an existing flag or create a new one
+3. **Configure Rule Groups**: Add rule groups with different logical operators
+4. **Add Rules**: Define individual targeting rules within each group
+5. **Test with Sample Data**: Use the test functionality with user contexts from `/TargetingExample/TestUserScenarios`
+6. **Save Configuration**: Save your targeting rules
+7. **Verify in Code**: Check the `/TargetingExample` endpoint to see how your rules affect feature evaluation
+
+## Dashboard Features
+
+- **Visual Rule Builder**: Create targeting rules without writing code
+- **Rule Groups**: Organize rules with AND/OR logic
+- **Priority Management**: Control evaluation order with numeric priorities
+- **Live Testing**: Test rules with sample user data before saving
+- **Rollout Percentages**: Set different rollout rates for each rule group
+- **Common Attributes**: Pre-populated suggestions for user attributes
+
+## Integration Tips
+
+1. **Start Simple**: Begin with basic rules and gradually add complexity
+2. **Test Thoroughly**: Use the test scenarios to validate your targeting logic
+3. **Monitor Usage**: Check the analytics dashboard to see how rules perform
+4. **Document Attributes**: Maintain a consistent set of user attributes across your application
+5. **Use Fallback Percentages**: Always set a fallback rollout percentage for users who don't match any rules

--- a/samples/SampleWebApp/Views/Home/Index.cshtml
+++ b/samples/SampleWebApp/Views/Home/Index.cshtml
@@ -37,6 +37,27 @@
                             </div>
                         </div>
                     </div>
+
+                    <div class="alert alert-success">
+                        <h6 class="alert-heading mb-2">
+                            <i class="bi bi-target me-2"></i>Targeting Rules Examples
+                        </h6>
+                        <p class="mb-2">Explore advanced targeting rules functionality:</p>
+                        <div class="d-flex flex-wrap gap-2">
+                            <a href="/TargetingExample" class="btn btn-sm btn-outline-success">
+                                <i class="bi bi-code-slash me-1"></i>API Examples
+                            </a>
+                            <a href="/TargetingExample/Dashboard" class="btn btn-sm btn-outline-success">
+                                <i class="bi bi-gear me-1"></i>Dashboard Guide
+                            </a>
+                            <a href="/TargetingExample/TestUserScenarios" class="btn btn-sm btn-outline-success">
+                                <i class="bi bi-people me-1"></i>Test Scenarios
+                            </a>
+                            <a href="/feature-flags/targeting-rules" class="btn btn-sm btn-success">
+                                <i class="bi bi-sliders me-1"></i>Configure Rules
+                            </a>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>

--- a/samples/SampleWebApp/Views/TargetingExample/Dashboard.cshtml
+++ b/samples/SampleWebApp/Views/TargetingExample/Dashboard.cshtml
@@ -1,0 +1,191 @@
+@model SampleWebApp.Models.DashboardGuideViewModel
+@{
+    ViewData["Title"] = "Dashboard Guide";
+}
+
+<div class="container py-4">
+    <div class="row mb-4">
+        <div class="col">
+            <div class="card shadow-sm">
+                <div class="card-header bg-success text-white">
+                    <h4 class="mb-0">
+                        <i class="bi bi-gear me-2"></i>Targeting Rules Dashboard Guide
+                    </h4>
+                </div>
+                <div class="card-body">
+                    <p class="mb-0">@Model.Message</p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="row mb-4">
+        <div class="col">
+            <div class="alert alert-primary">
+                <h6 class="alert-heading">
+                    <i class="bi bi-compass me-2"></i>Quick Navigation
+                </h6>
+                <div class="d-flex flex-wrap gap-2">
+                    <a href="@Model.DashboardUrl" class="btn btn-outline-primary btn-sm">
+                        <i class="bi bi-grid me-1"></i>Main Dashboard
+                    </a>
+                    <a href="@Model.TargetingRulesUrl" class="btn btn-primary btn-sm">
+                        <i class="bi bi-sliders me-1"></i>Targeting Rules
+                    </a>
+                    <a href="@Model.AnalyticsUrl" class="btn btn-outline-primary btn-sm">
+                        <i class="bi bi-graph-up me-1"></i>Analytics
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="row mb-4">
+        <div class="col-lg-6">
+            <div class="card shadow-sm">
+                <div class="card-header bg-light">
+                    <h5 class="mb-0">
+                        <i class="bi bi-list-check me-2"></i>Step-by-Step Instructions
+                    </h5>
+                </div>
+                <div class="card-body">
+                    <ol class="list-group list-group-numbered">
+                        @foreach (var instruction in Model.Instructions)
+                        {
+                            <li class="list-group-item border-0 ps-0">@instruction</li>
+                        }
+                    </ol>
+                </div>
+            </div>
+        </div>
+        <div class="col-lg-6">
+            <div class="card shadow-sm">
+                <div class="card-header bg-light">
+                    <h5 class="mb-0">
+                        <i class="bi bi-lightbulb me-2"></i>Pro Tips
+                    </h5>
+                </div>
+                <div class="card-body">
+                    <div class="alert alert-info mb-3">
+                        <strong>Rule Priority:</strong> Lower numbers = higher priority. Rules are evaluated in order.
+                    </div>
+                    <div class="alert alert-warning mb-3">
+                        <strong>Test First:</strong> Always test your rules with sample data before saving to production.
+                    </div>
+                    <div class="alert alert-success mb-0">
+                        <strong>Fallback Percentage:</strong> Set a fallback rollout percentage for users who don't match any rules.
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col">
+            <div class="card shadow-sm">
+                <div class="card-header bg-light">
+                    <h5 class="mb-0">
+                        <i class="bi bi-target me-2"></i>Example Targeting Scenarios
+                    </h5>
+                </div>
+                <div class="card-body">
+                    <div class="row">
+                        @foreach (var scenario in Model.ExampleTargetingScenarios)
+                        {
+                            <div class="col-lg-6 mb-4">
+                                <div class="card border-left-primary">
+                                    <div class="card-body">
+                                        <h6 class="card-title text-primary">@scenario.Name</h6>
+                                        <p class="card-text">@scenario.Description</p>
+                                        <div class="bg-light p-3 rounded">
+                                            <small class="text-muted d-block mb-1">Rule Example:</small>
+                                            <code>@scenario.RuleExample</code>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        }
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="row mt-4">
+        <div class="col">
+            <div class="card shadow-sm">
+                <div class="card-header bg-light">
+                    <h5 class="mb-0">Dashboard Features Overview</h5>
+                </div>
+                <div class="card-body">
+                    <div class="row">
+                        <div class="col-md-6">
+                            <h6><i class="bi bi-plus-circle me-2 text-success"></i>Rule Builder</h6>
+                            <ul>
+                                <li>Visual interface for creating targeting rules</li>
+                                <li>Support for 15+ operators (equals, contains, greater than, etc.)</li>
+                                <li>Autocomplete for common user attributes</li>
+                            </ul>
+                        </div>
+                        <div class="col-md-6">
+                            <h6><i class="bi bi-layers me-2 text-primary"></i>Rule Groups</h6>
+                            <ul>
+                                <li>Organize multiple rules with AND/OR logic</li>
+                                <li>Set priority order for evaluation</li>
+                                <li>Individual rollout percentages per group</li>
+                            </ul>
+                        </div>
+                        <div class="col-md-6">
+                            <h6><i class="bi bi-play-circle me-2 text-info"></i>Live Testing</h6>
+                            <ul>
+                                <li>Test rules with sample user data</li>
+                                <li>See real-time evaluation results</li>
+                                <li>Validate logic before saving</li>
+                            </ul>
+                        </div>
+                        <div class="col-md-6">
+                            <h6><i class="bi bi-bar-chart me-2 text-warning"></i>Analytics Integration</h6>
+                            <ul>
+                                <li>Monitor rule performance</li>
+                                <li>Track feature usage by user segments</li>
+                                <li>Analyze targeting effectiveness</li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="row mt-4">
+        <div class="col">
+            <div class="card shadow-sm">
+                <div class="card-header bg-light">
+                    <h5 class="mb-0">Next Steps</h5>
+                </div>
+                <div class="card-body">
+                    <div class="d-flex flex-wrap gap-2">
+                        <a href="/TargetingExample" class="btn btn-outline-primary">
+                            <i class="bi bi-code-slash me-1"></i>API Examples
+                        </a>
+                        <a href="/TargetingExample/TestUserScenarios" class="btn btn-outline-primary">
+                            <i class="bi bi-people me-1"></i>Test Scenarios
+                        </a>
+                        <a href="@Model.TargetingRulesUrl" class="btn btn-primary">
+                            <i class="bi bi-sliders me-1"></i>Start Configuring Rules
+                        </a>
+                        <a href="/" class="btn btn-outline-secondary">
+                            <i class="bi bi-house me-1"></i>Back to Home
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<style>
+.border-left-primary {
+    border-left: 4px solid #007bff !important;
+}
+</style>

--- a/samples/SampleWebApp/Views/TargetingExample/Index.cshtml
+++ b/samples/SampleWebApp/Views/TargetingExample/Index.cshtml
@@ -1,0 +1,202 @@
+@{
+    ViewData["Title"] = "Targeting Rules API Examples";
+}
+
+<div class="container py-4">
+    <div class="row mb-4">
+        <div class="col">
+            <div class="card shadow-sm">
+                <div class="card-header bg-primary text-white">
+                    <h4 class="mb-0">
+                        <i class="bi bi-code-slash me-2"></i>Targeting Rules API Examples
+                    </h4>
+                </div>
+                <div class="card-body">
+                    <p class="mb-0">This page demonstrates how to use ToggleNet's targeting rules in your code with various user contexts and scenarios.</p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="row mb-4">
+        <div class="col">
+            <div class="alert alert-info">
+                <h6 class="alert-heading">
+                    <i class="bi bi-info-circle me-2"></i>Live API Results
+                </h6>
+                <p class="mb-2">Click the button below to see real-time evaluation results from the ToggleNet API:</p>
+                <button id="loadResults" class="btn btn-primary">
+                    <i class="bi bi-play-circle me-2"></i>Load API Results
+                </button>
+            </div>
+        </div>
+    </div>
+
+    <div id="resultsContainer" class="d-none">
+        <div class="row">
+            <div class="col-lg-6 mb-4">
+                <div class="card shadow-sm">
+                    <div class="card-header bg-light">
+                        <h5 class="mb-0">Feature Evaluation Results</h5>
+                    </div>
+                    <div class="card-body">
+                        <div id="featureResults"></div>
+                    </div>
+                </div>
+            </div>
+            <div class="col-lg-6 mb-4">
+                <div class="card shadow-sm">
+                    <div class="card-header bg-light">
+                        <h5 class="mb-0">User Contexts</h5>
+                    </div>
+                    <div class="card-body">
+                        <div id="userContexts"></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col">
+            <div class="card shadow-sm">
+                <div class="card-header bg-light">
+                    <h5 class="mb-0">Example Code Implementation</h5>
+                </div>
+                <div class="card-body">
+                    <h6>1. Basic User Context</h6>
+                    <pre><code class="language-csharp">var basicUserContext = new UserContext
+{
+    UserId = "user123",
+    Attributes = new Dictionary&lt;string, object&gt;
+    {
+        ["country"] = "US",
+        ["userType"] = "premium"
+    }
+};
+
+bool isEnabled = await _featureFlagManager.IsEnabledAsync("basic-targeting", basicUserContext);</code></pre>
+
+                    <h6 class="mt-4">2. Complex Enterprise User Context</h6>
+                    <pre><code class="language-csharp">var complexUserContext = new UserContext
+{
+    UserId = "enterprise_user_456",
+    Attributes = new Dictionary&lt;string, object&gt;
+    {
+        ["country"] = "CA",
+        ["plan"] = "enterprise",
+        ["companySize"] = 1500,
+        ["industry"] = "technology",
+        ["appVersion"] = "3.2.1",
+        ["registrationDate"] = DateTime.Parse("2022-06-15"),
+        ["betaTester"] = true,
+        ["deviceType"] = "desktop",
+        ["email"] = "user@company.com"
+    }
+};
+
+bool isAdvancedEnabled = await _featureFlagManager.IsEnabledAsync("advanced-analytics", complexUserContext);</code></pre>
+
+                    <h6 class="mt-4">3. Simplified Overload</h6>
+                    <pre><code class="language-csharp">var mobileUserAttributes = new Dictionary&lt;string, object&gt;
+{
+    ["deviceType"] = "mobile",
+    ["osVersion"] = "iOS 17.0",
+    ["region"] = "north-america"
+};
+
+bool isMobileEnabled = await _featureFlagManager.IsEnabledAsync("mobile-optimization", "mobile_user_789", mobileUserAttributes);</code></pre>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="row mt-4">
+        <div class="col">
+            <div class="card shadow-sm">
+                <div class="card-header bg-light">
+                    <h5 class="mb-0">Next Steps</h5>
+                </div>
+                <div class="card-body">
+                    <div class="d-flex flex-wrap gap-2">
+                        <a href="/TargetingExample/Dashboard" class="btn btn-outline-primary">
+                            <i class="bi bi-gear me-1"></i>Dashboard Guide
+                        </a>
+                        <a href="/TargetingExample/TestUserScenarios" class="btn btn-outline-primary">
+                            <i class="bi bi-people me-1"></i>Test Scenarios
+                        </a>
+                        <a href="/feature-flags/targeting-rules" class="btn btn-primary">
+                            <i class="bi bi-sliders me-1"></i>Configure Rules
+                        </a>
+                        <a href="/" class="btn btn-outline-secondary">
+                            <i class="bi bi-house me-1"></i>Back to Home
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    <script>
+        document.getElementById('loadResults').addEventListener('click', function() {
+            const button = this;
+            button.disabled = true;
+            button.innerHTML = '<i class="bi bi-hourglass-split me-2"></i>Loading...';
+            
+            fetch('/TargetingExample?format=json')
+                .then(response => response.json())
+                .then(data => {
+                    // Show feature results
+                    const featureResults = document.getElementById('featureResults');
+                    let resultsHtml = '';
+                    
+                    Object.keys(data).forEach(key => {
+                        if (key !== 'UserContexts' && typeof data[key] === 'boolean') {
+                            const status = data[key] ? 'success' : 'secondary';
+                            const icon = data[key] ? 'check-circle' : 'x-circle';
+                            resultsHtml += `
+                                <div class="d-flex justify-content-between align-items-center mb-2">
+                                    <span>${key}</span>
+                                    <span class="badge bg-${status}">
+                                        <i class="bi bi-${icon} me-1"></i>${data[key] ? 'Enabled' : 'Disabled'}
+                                    </span>
+                                </div>
+                            `;
+                        }
+                    });
+                    featureResults.innerHTML = resultsHtml;
+                    
+                    // Show user contexts
+                    const userContexts = document.getElementById('userContexts');
+                    if (data.UserContexts) {
+                        let contextHtml = '';
+                        Object.keys(data.UserContexts).forEach(contextType => {
+                            const context = data.UserContexts[contextType];
+                            contextHtml += `
+                                <div class="mb-3">
+                                    <h6>${contextType} User</h6>
+                                    <small class="text-muted">User ID: ${context.UserId || context.userId}</small>
+                                    <pre class="small mt-1">${JSON.stringify(context.Attributes || context.attributes, null, 2)}</pre>
+                                </div>
+                            `;
+                        });
+                        userContexts.innerHTML = contextHtml;
+                    }
+                    
+                    // Show results container
+                    document.getElementById('resultsContainer').classList.remove('d-none');
+                    
+                    // Reset button
+                    button.disabled = false;
+                    button.innerHTML = '<i class="bi bi-arrow-clockwise me-2"></i>Reload Results';
+                })
+                .catch(error => {
+                    console.error('Error loading results:', error);
+                    button.disabled = false;
+                    button.innerHTML = '<i class="bi bi-exclamation-triangle me-2"></i>Error - Try Again';
+                });
+        });
+    </script>
+}

--- a/samples/SampleWebApp/Views/TargetingExample/TestUserScenarios.cshtml
+++ b/samples/SampleWebApp/Views/TargetingExample/TestUserScenarios.cshtml
@@ -1,0 +1,221 @@
+@model SampleWebApp.Models.TestUserScenariosViewModel
+@{
+    ViewData["Title"] = "Test User Scenarios";
+}
+
+<div class="container py-4">
+    <div class="row mb-4">
+        <div class="col">
+            <div class="card shadow-sm">
+                <div class="card-header bg-info text-white">
+                    <h4 class="mb-0">
+                        <i class="bi bi-people me-2"></i>Test User Scenarios
+                    </h4>
+                </div>
+                <div class="card-body">
+                    <p class="mb-0">@Model.Message</p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="row mb-4">
+        <div class="col">
+            <div class="alert alert-success">
+                <h6 class="alert-heading">
+                    <i class="bi bi-info-circle me-2"></i>How to Use These Scenarios
+                </h6>
+                <ol class="mb-0">
+                    @foreach (var instruction in Model.Instructions)
+                    {
+                        <li>@instruction</li>
+                    }
+                </ol>
+            </div>
+        </div>
+    </div>
+
+    <div class="row">
+        @foreach (var scenario in Model.TestScenarios)
+        {
+            <div class="col-xl-4 col-lg-6 mb-4">
+                <div class="card shadow-sm h-100">
+                    <div class="card-header bg-light">
+                        <h5 class="mb-0">
+                            <i class="bi bi-person-circle me-2"></i>@scenario.Name
+                        </h5>
+                    </div>
+                    <div class="card-body">
+                        <!-- User Context -->
+                        <div class="mb-3">
+                            <h6 class="text-primary">
+                                <i class="bi bi-gear me-1"></i>User Context
+                            </h6>
+                            <div class="bg-light p-3 rounded">
+                                <small class="text-muted d-block mb-1">User ID:</small>
+                                <code class="d-block mb-2">@scenario.UserContext.UserId</code>
+                                
+                                <small class="text-muted d-block mb-1">Attributes:</small>
+                                <div class="small">
+                                    @foreach (var attr in scenario.UserContext.Attributes)
+                                    {
+                                        <div class="d-flex justify-content-between border-bottom py-1">
+                                            <span class="text-muted">@attr.Key:</span>
+                                            <span><code>@attr.Value</code></span>
+                                        </div>
+                                    }
+                                </div>
+                            </div>
+                        </div>
+
+                        <!-- Feature Results -->
+                        <div class="mb-3">
+                            <h6 class="text-success">
+                                <i class="bi bi-toggles me-1"></i>Feature Evaluation Results
+                            </h6>
+                            <div class="list-group">
+                                @foreach (var result in scenario.FeatureResults)
+                                {
+                                    var badgeClass = result.Value ? "bg-success" : "bg-secondary";
+                                    var icon = result.Value ? "check-circle" : "x-circle";
+                                    <div class="list-group-item d-flex justify-content-between align-items-center py-2">
+                                        <small>@result.Key</small>
+                                        <span class="badge @badgeClass">
+                                            <i class="bi bi-@icon me-1"></i>@(result.Value ? "Enabled" : "Disabled")
+                                        </span>
+                                    </div>
+                                }
+                            </div>
+                        </div>
+
+                        <!-- Copy Button -->
+                        <div class="d-grid">
+                            <button class="btn btn-outline-primary btn-sm copy-json" 
+                                    data-user-id="@scenario.UserContext.UserId"
+                                    data-attributes="@System.Text.Json.JsonSerializer.Serialize(scenario.UserContext.Attributes)">
+                                <i class="bi bi-clipboard me-1"></i>Copy User Context JSON
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        }
+    </div>
+
+    <div class="row mt-4">
+        <div class="col">
+            <div class="card shadow-sm">
+                <div class="card-header bg-light">
+                    <h5 class="mb-0">
+                        <i class="bi bi-clipboard-data me-2"></i>JSON Test Data
+                    </h5>
+                </div>
+                <div class="card-body">
+                    <p>Use the buttons above to copy individual user contexts, or copy the complete test data below:</p>
+                    <div class="position-relative">
+                        <pre id="fullJsonData" class="bg-light p-3 rounded"><code>@{
+                            var testData = new List<object>();
+                            foreach (var scenario in Model.TestScenarios)
+                            {
+                                testData.Add(new { 
+                                    Name = scenario.Name, 
+                                    UserId = scenario.UserContext.UserId, 
+                                    Attributes = scenario.UserContext.Attributes 
+                                });
+                            }
+                            var jsonOptions = new System.Text.Json.JsonSerializerOptions { WriteIndented = true };
+                        }@System.Text.Json.JsonSerializer.Serialize(testData, jsonOptions)</code></pre>
+                        <button class="btn btn-outline-secondary btn-sm position-absolute top-0 end-0 m-2" onclick="copyFullJson()">
+                            <i class="bi bi-clipboard me-1"></i>Copy All
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="row mt-4">
+        <div class="col">
+            <div class="card shadow-sm">
+                <div class="card-header bg-light">
+                    <h5 class="mb-0">Next Steps</h5>
+                </div>
+                <div class="card-body">
+                    <div class="d-flex flex-wrap gap-2">
+                        <a href="/TargetingExample" class="btn btn-outline-primary">
+                            <i class="bi bi-code-slash me-1"></i>API Examples
+                        </a>
+                        <a href="/TargetingExample/Dashboard" class="btn btn-outline-primary">
+                            <i class="bi bi-gear me-1"></i>Dashboard Guide
+                        </a>
+                        <a href="/feature-flags/targeting-rules" class="btn btn-primary">
+                            <i class="bi bi-sliders me-1"></i>Test These Scenarios
+                        </a>
+                        <a href="/" class="btn btn-outline-secondary">
+                            <i class="bi bi-house me-1"></i>Back to Home
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Toast for copy notifications -->
+<div class="toast-container position-fixed bottom-0 end-0 p-3">
+    <div id="copyToast" class="toast" role="alert">
+        <div class="toast-header">
+            <i class="bi bi-check-circle text-success me-2"></i>
+            <strong class="me-auto">Copied!</strong>
+            <button type="button" class="btn-close" data-bs-dismiss="toast"></button>
+        </div>
+        <div class="toast-body">
+            User context copied to clipboard.
+        </div>
+    </div>
+</div>
+
+@section Scripts {
+    <script>
+        // Copy individual user context
+        document.querySelectorAll('.copy-json').forEach(button => {
+            button.addEventListener('click', function() {
+                const userId = this.dataset.userId;
+                const attributes = JSON.parse(this.dataset.attributes);
+                
+                const userContext = {
+                    UserId: userId,
+                    Attributes: attributes
+                };
+                
+                const jsonString = JSON.stringify(userContext, null, 2);
+                
+                navigator.clipboard.writeText(jsonString).then(() => {
+                    showToast('User context copied to clipboard!');
+                }).catch(err => {
+                    console.error('Failed to copy: ', err);
+                });
+            });
+        });
+        
+        // Copy full JSON data
+        function copyFullJson() {
+            const jsonData = document.getElementById('fullJsonData').textContent;
+            navigator.clipboard.writeText(jsonData).then(() => {
+                showToast('All test scenarios copied to clipboard!');
+            }).catch(err => {
+                console.error('Failed to copy: ', err);
+            });
+        }
+        
+        // Show toast notification
+        function showToast(message) {
+            const toastElement = document.getElementById('copyToast');
+            const toastBody = toastElement.querySelector('.toast-body');
+            toastBody.textContent = message;
+            
+            const toast = new bootstrap.Toast(toastElement);
+            toast.show();
+        }
+    </script>
+}

--- a/src/ToggleNet.Core/Entities/FeatureFlag.cs
+++ b/src/ToggleNet.Core/Entities/FeatureFlag.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace ToggleNet.Core.Entities
 {
@@ -29,6 +30,7 @@ namespace ToggleNet.Core.Entities
         
         /// <summary>
         /// Percentage of users who should see this feature (0-100)
+        /// Used as fallback when no targeting rules match
         /// </summary>
         public int RolloutPercentage { get; set; }
         
@@ -41,5 +43,15 @@ namespace ToggleNet.Core.Entities
         /// When the flag was last updated
         /// </summary>
         public DateTime UpdatedAt { get; set; }
+        
+        /// <summary>
+        /// Targeting rule groups for this feature flag
+        /// </summary>
+        public List<TargetingRuleGroup> TargetingRuleGroups { get; set; } = new();
+        
+        /// <summary>
+        /// Whether to use targeting rules or fall back to percentage rollout
+        /// </summary>
+        public bool UseTargetingRules { get; set; } = false;
     }
 }

--- a/src/ToggleNet.Core/Entities/TargetingRule.cs
+++ b/src/ToggleNet.Core/Entities/TargetingRule.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Collections.Generic;
+
+namespace ToggleNet.Core.Entities
+{
+    /// <summary>
+    /// Represents a targeting rule for feature flag evaluation
+    /// </summary>
+    public class TargetingRule
+    {
+        /// <summary>
+        /// Unique identifier for the targeting rule
+        /// </summary>
+        public Guid Id { get; set; }
+        
+        /// <summary>
+        /// Name of the targeting rule
+        /// </summary>
+        public string Name { get; set; } = null!;
+        
+        /// <summary>
+        /// The attribute to evaluate (e.g., "country", "userType", "deviceType")
+        /// </summary>
+        public string Attribute { get; set; } = null!;
+        
+        /// <summary>
+        /// The operator to use for comparison
+        /// </summary>
+        public TargetingOperator Operator { get; set; }
+        
+        /// <summary>
+        /// The value(s) to compare against (JSON serialized for complex types)
+        /// </summary>
+        public string Value { get; set; } = null!;
+        
+        /// <summary>
+        /// Priority order for rule evaluation (lower numbers evaluated first)
+        /// </summary>
+        public int Priority { get; set; }
+        
+        /// <summary>
+        /// Whether this rule is currently active
+        /// </summary>
+        public bool IsEnabled { get; set; } = true;
+    }
+    
+    /// <summary>
+    /// Operators for targeting rule evaluation
+    /// </summary>
+    public enum TargetingOperator
+    {
+        /// <summary>
+        /// Exact string match
+        /// </summary>
+        Equals,
+        
+        /// <summary>
+        /// Case-insensitive string match
+        /// </summary>
+        EqualsIgnoreCase,
+        
+        /// <summary>
+        /// Not equal to
+        /// </summary>
+        NotEquals,
+        
+        /// <summary>
+        /// Value is in a list of values
+        /// </summary>
+        In,
+        
+        /// <summary>
+        /// Value is not in a list of values
+        /// </summary>
+        NotIn,
+        
+        /// <summary>
+        /// String contains substring
+        /// </summary>
+        Contains,
+        
+        /// <summary>
+        /// String does not contain substring
+        /// </summary>
+        NotContains,
+        
+        /// <summary>
+        /// String starts with
+        /// </summary>
+        StartsWith,
+        
+        /// <summary>
+        /// String ends with
+        /// </summary>
+        EndsWith,
+        
+        /// <summary>
+        /// Regular expression match
+        /// </summary>
+        Regex,
+        
+        /// <summary>
+        /// Numeric greater than
+        /// </summary>
+        GreaterThan,
+        
+        /// <summary>
+        /// Numeric greater than or equal
+        /// </summary>
+        GreaterThanOrEqual,
+        
+        /// <summary>
+        /// Numeric less than
+        /// </summary>
+        LessThan,
+        
+        /// <summary>
+        /// Numeric less than or equal
+        /// </summary>
+        LessThanOrEqual,
+        
+        /// <summary>
+        /// Date/time before
+        /// </summary>
+        Before,
+        
+        /// <summary>
+        /// Date/time after
+        /// </summary>
+        After,
+        
+        /// <summary>
+        /// Version comparison (semantic versioning)
+        /// </summary>
+        VersionGreaterThan,
+        
+        /// <summary>
+        /// Version comparison (semantic versioning)
+        /// </summary>
+        VersionLessThan
+    }
+}

--- a/src/ToggleNet.Core/Entities/TargetingRuleGroup.cs
+++ b/src/ToggleNet.Core/Entities/TargetingRuleGroup.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+
+namespace ToggleNet.Core.Entities
+{
+    /// <summary>
+    /// Represents a group of targeting rules that can be combined with logical operators
+    /// </summary>
+    public class TargetingRuleGroup
+    {
+        /// <summary>
+        /// Unique identifier for the rule group
+        /// </summary>
+        public Guid Id { get; set; }
+        
+        /// <summary>
+        /// Name of the rule group
+        /// </summary>
+        public string Name { get; set; } = null!;
+        
+        /// <summary>
+        /// The feature flag this rule group belongs to
+        /// </summary>
+        public Guid FeatureFlagId { get; set; }
+        
+        /// <summary>
+        /// Logical operator to combine rules within this group
+        /// </summary>
+        public LogicalOperator LogicalOperator { get; set; } = LogicalOperator.And;
+        
+        /// <summary>
+        /// The rules in this group
+        /// </summary>
+        public List<TargetingRule> Rules { get; set; } = new();
+        
+        /// <summary>
+        /// Priority order for rule group evaluation (lower numbers evaluated first)
+        /// </summary>
+        public int Priority { get; set; }
+        
+        /// <summary>
+        /// Whether this rule group is currently active
+        /// </summary>
+        public bool IsEnabled { get; set; } = true;
+        
+        /// <summary>
+        /// The percentage rollout for users matching this rule group (0-100)
+        /// </summary>
+        public int RolloutPercentage { get; set; } = 100;
+    }
+    
+    /// <summary>
+    /// Logical operators for combining rules
+    /// </summary>
+    public enum LogicalOperator
+    {
+        /// <summary>
+        /// All rules must match
+        /// </summary>
+        And,
+        
+        /// <summary>
+        /// At least one rule must match
+        /// </summary>
+        Or
+    }
+}

--- a/src/ToggleNet.Core/Entities/UserContext.cs
+++ b/src/ToggleNet.Core/Entities/UserContext.cs
@@ -1,0 +1,65 @@
+using System.Collections.Generic;
+
+namespace ToggleNet.Core.Entities
+{
+    /// <summary>
+    /// Represents user context for targeting rule evaluation
+    /// </summary>
+    public class UserContext
+    {
+        /// <summary>
+        /// User identifier
+        /// </summary>
+        public string UserId { get; set; } = null!;
+        
+        /// <summary>
+        /// User attributes for targeting evaluation
+        /// Key-value pairs where key is the attribute name and value is the attribute value
+        /// </summary>
+        public Dictionary<string, object> Attributes { get; set; } = new();
+        
+        /// <summary>
+        /// Helper method to get an attribute value with type conversion
+        /// </summary>
+        /// <typeparam name="T">The type to convert to</typeparam>
+        /// <param name="key">The attribute key</param>
+        /// <returns>The converted value or default(T) if not found or conversion fails</returns>
+        public T? GetAttribute<T>(string key)
+        {
+            if (!Attributes.TryGetValue(key, out var value))
+                return default(T);
+                
+            try
+            {
+                if (value is T directValue)
+                    return directValue;
+                    
+                return (T)System.Convert.ChangeType(value, typeof(T));
+            }
+            catch
+            {
+                return default(T);
+            }
+        }
+        
+        /// <summary>
+        /// Helper method to get an attribute value as string
+        /// </summary>
+        /// <param name="key">The attribute key</param>
+        /// <returns>The attribute value as string or null if not found</returns>
+        public string? GetAttributeAsString(string key)
+        {
+            return Attributes.TryGetValue(key, out var value) ? value?.ToString() : null;
+        }
+        
+        /// <summary>
+        /// Helper method to check if an attribute exists
+        /// </summary>
+        /// <param name="key">The attribute key</param>
+        /// <returns>True if the attribute exists, false otherwise</returns>
+        public bool HasAttribute(string key)
+        {
+            return Attributes.ContainsKey(key);
+        }
+    }
+}

--- a/src/ToggleNet.Core/Samples/TargetingRulesSample.cs
+++ b/src/ToggleNet.Core/Samples/TargetingRulesSample.cs
@@ -1,0 +1,185 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using ToggleNet.Core;
+using ToggleNet.Core.Entities;
+
+namespace ToggleNet.Samples
+{
+    /// <summary>
+    /// Sample code demonstrating how to use the Targeting Rules Engine
+    /// </summary>
+    public class TargetingRulesSample
+    {
+        private readonly FeatureFlagManager _featureFlagManager;
+
+        public TargetingRulesSample(FeatureFlagManager featureFlagManager)
+        {
+            _featureFlagManager = featureFlagManager;
+        }
+
+        /// <summary>
+        /// Example of using targeting rules with user attributes
+        /// </summary>
+        public async Task<bool> CheckFeatureWithUserAttributes()
+        {
+            // Create user context with attributes
+            var userContext = new UserContext
+            {
+                UserId = "user123",
+                Attributes = new Dictionary<string, object>
+                {
+                    ["country"] = "US",
+                    ["userType"] = "premium",
+                    ["age"] = 25,
+                    ["deviceType"] = "mobile",
+                    ["appVersion"] = "2.1.0",
+                    ["registrationDate"] = DateTime.Parse("2023-01-15")
+                }
+            };
+
+            // Check if feature is enabled using targeting rules
+            return await _featureFlagManager.IsEnabledAsync("advanced-analytics", userContext);
+        }
+
+        /// <summary>
+        /// Example of using the simplified overload with user attributes
+        /// </summary>
+        public async Task<bool> CheckFeatureWithAttributesDictionary()
+        {
+            var userAttributes = new Dictionary<string, object>
+            {
+                ["country"] = "CA",
+                ["plan"] = "enterprise",
+                ["companySize"] = 500
+            };
+
+            return await _featureFlagManager.IsEnabledAsync("enterprise-features", "user456", userAttributes);
+        }
+
+        /// <summary>
+        /// Example targeting rule configurations that could be created via the dashboard
+        /// </summary>
+        public static FeatureFlag CreateSampleFeatureFlagWithTargetingRules()
+        {
+            return new FeatureFlag
+            {
+                Id = Guid.NewGuid(),
+                Name = "advanced-analytics",
+                Description = "Advanced analytics dashboard for premium users",
+                IsEnabled = true,
+                Environment = "Production",
+                UseTargetingRules = true,
+                RolloutPercentage = 10, // Fallback percentage if no rules match
+                UpdatedAt = DateTime.UtcNow,
+                TargetingRuleGroups = new List<TargetingRuleGroup>
+                {
+                    // Rule Group 1: Premium users in US/CA
+                    new TargetingRuleGroup
+                    {
+                        Id = Guid.NewGuid(),
+                        Name = "Premium North America",
+                        FeatureFlagId = Guid.NewGuid(),
+                        LogicalOperator = LogicalOperator.And,
+                        Priority = 1,
+                        IsEnabled = true,
+                        RolloutPercentage = 100,
+                        Rules = new List<TargetingRule>
+                        {
+                            new TargetingRule
+                            {
+                                Id = Guid.NewGuid(),
+                                Name = "Premium User Type",
+                                Attribute = "userType",
+                                Operator = TargetingOperator.In,
+                                Value = "[\"premium\", \"enterprise\"]",
+                                Priority = 1,
+                                IsEnabled = true
+                            },
+                            new TargetingRule
+                            {
+                                Id = Guid.NewGuid(),
+                                Name = "North America Countries",
+                                Attribute = "country",
+                                Operator = TargetingOperator.In,
+                                Value = "[\"US\", \"CA\"]",
+                                Priority = 2,
+                                IsEnabled = true
+                            }
+                        }
+                    },
+                    
+                    // Rule Group 2: Beta testers with specific app version
+                    new TargetingRuleGroup
+                    {
+                        Id = Guid.NewGuid(),
+                        Name = "Beta Testers",
+                        FeatureFlagId = Guid.NewGuid(),
+                        LogicalOperator = LogicalOperator.And,
+                        Priority = 2,
+                        IsEnabled = true,
+                        RolloutPercentage = 50, // Only 50% of matching users
+                        Rules = new List<TargetingRule>
+                        {
+                            new TargetingRule
+                            {
+                                Id = Guid.NewGuid(),
+                                Name = "Beta User",
+                                Attribute = "betaTester",
+                                Operator = TargetingOperator.Equals,
+                                Value = "true",
+                                Priority = 1,
+                                IsEnabled = true
+                            },
+                            new TargetingRule
+                            {
+                                Id = Guid.NewGuid(),
+                                Name = "Minimum App Version",
+                                Attribute = "appVersion",
+                                Operator = TargetingOperator.VersionGreaterThan,
+                                Value = "2.0.0",
+                                Priority = 2,
+                                IsEnabled = true
+                            }
+                        }
+                    },
+                    
+                    // Rule Group 3: Large companies (OR logic example)
+                    new TargetingRuleGroup
+                    {
+                        Id = Guid.NewGuid(),
+                        Name = "Large Companies",
+                        FeatureFlagId = Guid.NewGuid(),
+                        LogicalOperator = LogicalOperator.Or,
+                        Priority = 3,
+                        IsEnabled = true,
+                        RolloutPercentage = 25,
+                        Rules = new List<TargetingRule>
+                        {
+                            new TargetingRule
+                            {
+                                Id = Guid.NewGuid(),
+                                Name = "Large Company Size",
+                                Attribute = "companySize",
+                                Operator = TargetingOperator.GreaterThan,
+                                Value = "1000",
+                                Priority = 1,
+                                IsEnabled = true
+                            },
+                            new TargetingRule
+                            {
+                                Id = Guid.NewGuid(),
+                                Name = "Enterprise Plan",
+                                Attribute = "plan",
+                                Operator = TargetingOperator.EqualsIgnoreCase,
+                                Value = "enterprise",
+                                Priority = 2,
+                                IsEnabled = true
+                            }
+                        }
+                    }
+                }
+            };
+        }
+    }
+}

--- a/src/ToggleNet.Core/Storage/IFeatureStore.cs
+++ b/src/ToggleNet.Core/Storage/IFeatureStore.cs
@@ -80,5 +80,55 @@ namespace ToggleNet.Core.Storage
         /// <param name="count">Maximum number of records to return</param>
         /// <returns>Collection of recent feature usage events</returns>
         Task<IEnumerable<FeatureUsage>> GetRecentFeatureUsagesAsync(string environment, int count = 50);
+        
+        /// <summary>
+        /// Saves or updates a targeting rule group
+        /// </summary>
+        /// <param name="ruleGroup">The targeting rule group to save</param>
+        Task SaveTargetingRuleGroupAsync(TargetingRuleGroup ruleGroup);
+        
+        /// <summary>
+        /// Gets all targeting rule groups for a feature flag
+        /// </summary>
+        /// <param name="featureFlagId">The feature flag ID</param>
+        /// <returns>Collection of targeting rule groups</returns>
+        Task<IEnumerable<TargetingRuleGroup>> GetTargetingRuleGroupsAsync(Guid featureFlagId);
+        
+        /// <summary>
+        /// Deletes a targeting rule group
+        /// </summary>
+        /// <param name="ruleGroupId">The ID of the rule group to delete</param>
+        Task DeleteTargetingRuleGroupAsync(Guid ruleGroupId);
+        
+        /// <summary>
+        /// Saves or updates a targeting rule
+        /// </summary>
+        /// <param name="rule">The targeting rule to save</param>
+        Task SaveTargetingRuleAsync(TargetingRule rule);
+        
+        /// <summary>
+        /// Deletes a targeting rule
+        /// </summary>
+        /// <param name="ruleId">The ID of the rule to delete</param>
+        Task DeleteTargetingRuleAsync(Guid ruleId);
+
+        /// <summary>
+        /// Creates a new targeting rule group
+        /// </summary>
+        /// <param name="ruleGroup">The targeting rule group to create</param>
+        Task CreateTargetingRuleGroupAsync(TargetingRuleGroup ruleGroup);
+        
+        /// <summary>
+        /// Clears all targeting rule groups for a feature flag
+        /// </summary>
+        /// <param name="featureFlagId">The feature flag ID</param>
+        Task ClearTargetingRuleGroupsAsync(Guid featureFlagId);
+        
+        /// <summary>
+        /// Updates the UseTargetingRules property for a feature flag
+        /// </summary>
+        /// <param name="featureFlagId">The feature flag ID</param>
+        /// <param name="useTargetingRules">Whether to use targeting rules</param>
+        Task UpdateFlagTargetingAsync(Guid featureFlagId, bool useTargetingRules);
     }
 }

--- a/src/ToggleNet.Core/Targeting/ITargetingRulesEngine.cs
+++ b/src/ToggleNet.Core/Targeting/ITargetingRulesEngine.cs
@@ -1,0 +1,35 @@
+using System.Threading.Tasks;
+using ToggleNet.Core.Entities;
+
+namespace ToggleNet.Core.Targeting
+{
+    /// <summary>
+    /// Interface for evaluating targeting rules
+    /// </summary>
+    public interface ITargetingRulesEngine
+    {
+        /// <summary>
+        /// Evaluates whether a feature flag should be enabled for a user based on targeting rules
+        /// </summary>
+        /// <param name="featureFlag">The feature flag to evaluate</param>
+        /// <param name="userContext">The user context containing attributes for evaluation</param>
+        /// <returns>True if the feature should be enabled for the user, false otherwise</returns>
+        Task<bool> EvaluateAsync(FeatureFlag featureFlag, UserContext userContext);
+        
+        /// <summary>
+        /// Evaluates a single targeting rule against user context
+        /// </summary>
+        /// <param name="rule">The targeting rule to evaluate</param>
+        /// <param name="userContext">The user context containing attributes for evaluation</param>
+        /// <returns>True if the rule matches, false otherwise</returns>
+        bool EvaluateRule(TargetingRule rule, UserContext userContext);
+        
+        /// <summary>
+        /// Evaluates a targeting rule group against user context
+        /// </summary>
+        /// <param name="ruleGroup">The targeting rule group to evaluate</param>
+        /// <param name="userContext">The user context containing attributes for evaluation</param>
+        /// <returns>True if the rule group matches, false otherwise</returns>
+        Task<bool> EvaluateRuleGroupAsync(TargetingRuleGroup ruleGroup, UserContext userContext);
+    }
+}

--- a/src/ToggleNet.Core/Targeting/TargetingRulesEngine.cs
+++ b/src/ToggleNet.Core/Targeting/TargetingRulesEngine.cs
@@ -1,0 +1,259 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using ToggleNet.Core.Entities;
+
+namespace ToggleNet.Core.Targeting
+{
+    /// <summary>
+    /// Default implementation of the targeting rules engine
+    /// </summary>
+    public class TargetingRulesEngine : ITargetingRulesEngine
+    {
+        /// <summary>
+        /// Evaluates whether a feature flag should be enabled for a user based on targeting rules
+        /// </summary>
+        /// <param name="featureFlag">The feature flag to evaluate</param>
+        /// <param name="userContext">The user context containing attributes for evaluation</param>
+        /// <returns>True if the feature should be enabled for the user, false otherwise</returns>
+        public async Task<bool> EvaluateAsync(FeatureFlag featureFlag, UserContext userContext)
+        {
+            if (featureFlag == null || !featureFlag.IsEnabled)
+                return false;
+                
+            // If not using targeting rules, fall back to percentage rollout
+            if (!featureFlag.UseTargetingRules || !featureFlag.TargetingRuleGroups.Any())
+            {
+                return EvaluatePercentageRollout(userContext.UserId, featureFlag.Name, featureFlag.RolloutPercentage);
+            }
+            
+            // Evaluate targeting rule groups in priority order
+            var sortedRuleGroups = featureFlag.TargetingRuleGroups
+                .Where(rg => rg.IsEnabled)
+                .OrderBy(rg => rg.Priority)
+                .ToList();
+                
+            foreach (var ruleGroup in sortedRuleGroups)
+            {
+                var groupMatches = await EvaluateRuleGroupAsync(ruleGroup, userContext);
+                if (groupMatches)
+                {
+                    // If rule group matches, check its rollout percentage
+                    return EvaluatePercentageRollout(userContext.UserId, featureFlag.Name, ruleGroup.RolloutPercentage);
+                }
+            }
+            
+            // Fall back to default rollout percentage (current behavior)
+            return EvaluatePercentageRollout(userContext.UserId, featureFlag.Name, featureFlag.RolloutPercentage);
+        }
+        
+        /// <summary>
+        /// Evaluates a targeting rule group against user context
+        /// </summary>
+        /// <param name="ruleGroup">The targeting rule group to evaluate</param>
+        /// <param name="userContext">The user context containing attributes for evaluation</param>
+        /// <returns>True if the rule group matches, false otherwise</returns>
+        public Task<bool> EvaluateRuleGroupAsync(TargetingRuleGroup ruleGroup, UserContext userContext)
+        {
+            if (ruleGroup == null || !ruleGroup.IsEnabled || !ruleGroup.Rules.Any())
+                return Task.FromResult(false);
+                
+            var activeRules = ruleGroup.Rules.Where(r => r.IsEnabled).OrderBy(r => r.Priority).ToList();
+            
+            if (!activeRules.Any())
+                return Task.FromResult(false);
+                
+            var result = ruleGroup.LogicalOperator switch
+            {
+                LogicalOperator.And => activeRules.All(rule => EvaluateRule(rule, userContext)),
+                LogicalOperator.Or => activeRules.Any(rule => EvaluateRule(rule, userContext)),
+                _ => false
+            };
+            
+            return Task.FromResult(result);
+        }
+        
+        /// <summary>
+        /// Evaluates a single targeting rule against user context
+        /// </summary>
+        /// <param name="rule">The targeting rule to evaluate</param>
+        /// <param name="userContext">The user context containing attributes for evaluation</param>
+        /// <returns>True if the rule matches, false otherwise</returns>
+        public bool EvaluateRule(TargetingRule rule, UserContext userContext)
+        {
+            if (rule == null || !rule.IsEnabled)
+                return false;
+                
+            var userValue = userContext.GetAttributeAsString(rule.Attribute);
+            
+            return rule.Operator switch
+            {
+                TargetingOperator.Equals => EvaluateEquals(userValue, rule.Value),
+                TargetingOperator.EqualsIgnoreCase => EvaluateEqualsIgnoreCase(userValue, rule.Value),
+                TargetingOperator.NotEquals => !EvaluateEquals(userValue, rule.Value),
+                TargetingOperator.In => EvaluateIn(userValue, rule.Value),
+                TargetingOperator.NotIn => !EvaluateIn(userValue, rule.Value),
+                TargetingOperator.Contains => EvaluateContains(userValue, rule.Value),
+                TargetingOperator.NotContains => !EvaluateContains(userValue, rule.Value),
+                TargetingOperator.StartsWith => EvaluateStartsWith(userValue, rule.Value),
+                TargetingOperator.EndsWith => EvaluateEndsWith(userValue, rule.Value),
+                TargetingOperator.Regex => EvaluateRegex(userValue, rule.Value),
+                TargetingOperator.GreaterThan => EvaluateGreaterThan(userValue, rule.Value),
+                TargetingOperator.GreaterThanOrEqual => EvaluateGreaterThanOrEqual(userValue, rule.Value),
+                TargetingOperator.LessThan => EvaluateLessThan(userValue, rule.Value),
+                TargetingOperator.LessThanOrEqual => EvaluateLessThanOrEqual(userValue, rule.Value),
+                TargetingOperator.Before => EvaluateBefore(userValue, rule.Value),
+                TargetingOperator.After => EvaluateAfter(userValue, rule.Value),
+                TargetingOperator.VersionGreaterThan => EvaluateVersionGreaterThan(userValue, rule.Value),
+                TargetingOperator.VersionLessThan => EvaluateVersionLessThan(userValue, rule.Value),
+                _ => false
+            };
+        }
+        
+        private bool EvaluateEquals(string? userValue, string ruleValue)
+        {
+            return string.Equals(userValue, ruleValue, StringComparison.Ordinal);
+        }
+        
+        private bool EvaluateEqualsIgnoreCase(string? userValue, string ruleValue)
+        {
+            return string.Equals(userValue, ruleValue, StringComparison.OrdinalIgnoreCase);
+        }
+        
+        private bool EvaluateIn(string? userValue, string ruleValue)
+        {
+            if (userValue == null) return false;
+            
+            try
+            {
+                var values = JsonSerializer.Deserialize<List<string>>(ruleValue);
+                return values?.Any(v => string.Equals(v, userValue, StringComparison.OrdinalIgnoreCase)) ?? false;
+            }
+            catch
+            {
+                // Fallback to comma-separated values
+                var values = ruleValue.Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
+                    .Select(v => v.Trim())
+                    .ToList();
+                return values.Any(v => string.Equals(v, userValue, StringComparison.OrdinalIgnoreCase));
+            }
+        }
+        
+        private bool EvaluateContains(string? userValue, string ruleValue)
+        {
+            return userValue?.IndexOf(ruleValue, StringComparison.OrdinalIgnoreCase) >= 0;
+        }
+        
+        private bool EvaluateStartsWith(string? userValue, string ruleValue)
+        {
+            return userValue?.StartsWith(ruleValue, StringComparison.OrdinalIgnoreCase) ?? false;
+        }
+        
+        private bool EvaluateEndsWith(string? userValue, string ruleValue)
+        {
+            return userValue?.EndsWith(ruleValue, StringComparison.OrdinalIgnoreCase) ?? false;
+        }
+        
+        private bool EvaluateRegex(string? userValue, string ruleValue)
+        {
+            if (userValue == null) return false;
+            
+            try
+            {
+                return Regex.IsMatch(userValue, ruleValue, RegexOptions.IgnoreCase, TimeSpan.FromMilliseconds(100));
+            }
+            catch
+            {
+                return false;
+            }
+        }
+        
+        private bool EvaluateGreaterThan(string? userValue, string ruleValue)
+        {
+            return CompareNumeric(userValue, ruleValue, (user, rule) => user > rule);
+        }
+        
+        private bool EvaluateGreaterThanOrEqual(string? userValue, string ruleValue)
+        {
+            return CompareNumeric(userValue, ruleValue, (user, rule) => user >= rule);
+        }
+        
+        private bool EvaluateLessThan(string? userValue, string ruleValue)
+        {
+            return CompareNumeric(userValue, ruleValue, (user, rule) => user < rule);
+        }
+        
+        private bool EvaluateLessThanOrEqual(string? userValue, string ruleValue)
+        {
+            return CompareNumeric(userValue, ruleValue, (user, rule) => user <= rule);
+        }
+        
+        private bool CompareNumeric(string? userValue, string ruleValue, Func<double, double, bool> comparer)
+        {
+            if (userValue == null) return false;
+            
+            if (double.TryParse(userValue, NumberStyles.Number, CultureInfo.InvariantCulture, out var userNumeric) &&
+                double.TryParse(ruleValue, NumberStyles.Number, CultureInfo.InvariantCulture, out var ruleNumeric))
+            {
+                return comparer(userNumeric, ruleNumeric);
+            }
+            
+            return false;
+        }
+        
+        private bool EvaluateBefore(string? userValue, string ruleValue)
+        {
+            return CompareDateTime(userValue, ruleValue, (user, rule) => user < rule);
+        }
+        
+        private bool EvaluateAfter(string? userValue, string ruleValue)
+        {
+            return CompareDateTime(userValue, ruleValue, (user, rule) => user > rule);
+        }
+        
+        private bool CompareDateTime(string? userValue, string ruleValue, Func<DateTime, DateTime, bool> comparer)
+        {
+            if (userValue == null) return false;
+            
+            if (DateTime.TryParse(userValue, CultureInfo.InvariantCulture, DateTimeStyles.None, out var userDateTime) &&
+                DateTime.TryParse(ruleValue, CultureInfo.InvariantCulture, DateTimeStyles.None, out var ruleDateTime))
+            {
+                return comparer(userDateTime, ruleDateTime);
+            }
+            
+            return false;
+        }
+        
+        private bool EvaluateVersionGreaterThan(string? userValue, string ruleValue)
+        {
+            return CompareVersion(userValue, ruleValue, (user, rule) => user > rule);
+        }
+        
+        private bool EvaluateVersionLessThan(string? userValue, string ruleValue)
+        {
+            return CompareVersion(userValue, ruleValue, (user, rule) => user < rule);
+        }
+        
+        private bool CompareVersion(string? userValue, string ruleValue, Func<Version, Version, bool> comparer)
+        {
+            if (userValue == null) return false;
+            
+            if (Version.TryParse(userValue, out var userVersion) &&
+                Version.TryParse(ruleValue, out var ruleVersion))
+            {
+                return comparer(userVersion, ruleVersion);
+            }
+            
+            return false;
+        }
+        
+        private bool EvaluatePercentageRollout(string userId, string featureName, int rolloutPercentage)
+        {
+            return FeatureEvaluator.IsInRolloutPercentage(userId, featureName, rolloutPercentage);
+        }
+    }
+}

--- a/src/ToggleNet.Dashboard/DashboardExtensions.cs
+++ b/src/ToggleNet.Dashboard/DashboardExtensions.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.AspNetCore.StaticFiles;
 using System;
 using ToggleNet.Dashboard.Auth;
 
@@ -60,8 +61,6 @@ namespace ToggleNet.Dashboard
         {
             if (app == null)
                 throw new ArgumentNullException(nameof(app));
-                
-            app.UseStaticFiles();
 
             // Create auth options if needed
             var authOptions = new DashboardAuthOptions { BasePath = pathMatch };
@@ -69,6 +68,15 @@ namespace ToggleNet.Dashboard
             // Map the dashboard to the specified path
             app.Map(pathMatch, dashboardApp =>
             {
+                // Serve static files from the dashboard's wwwroot within the dashboard path
+                dashboardApp.UseStaticFiles(new StaticFileOptions
+                {
+                    FileProvider = new Microsoft.Extensions.FileProviders.EmbeddedFileProvider(
+                        typeof(DashboardExtensions).Assembly,
+                        "ToggleNet.Dashboard.wwwroot"),
+                    RequestPath = ""
+                });
+                
                 dashboardApp.UseRouting();
                 
                 // Add authentication middleware if required

--- a/src/ToggleNet.Dashboard/Pages/Index.cshtml
+++ b/src/ToggleNet.Dashboard/Pages/Index.cshtml
@@ -12,6 +12,9 @@
             <p class="text-muted">Managing features for <span class="badge bg-primary">@Model.Environment</span> environment</p>
         </div>
         <div>
+            <a href="@Url.Page("/TargetingRules")" class="btn btn-outline-primary me-2">
+                <i class="bi bi-target me-2"></i>Targeting Rules
+            </a>
             <button type="button" class="btn btn-success" data-bs-toggle="modal" data-bs-target="#createFlagModal">
                 <i class="bi bi-plus-circle me-2"></i>Add New Flag
             </button>
@@ -37,6 +40,7 @@
                                     <th>Description</th>
                                     <th class="text-center">Enabled</th>
                                     <th>Rollout %</th>
+                                    <th class="text-center">Targeting Rules</th>
                                     <th>Updated</th>
                                     <th class="text-end pe-4">Actions</th>
                                 </tr>
@@ -45,7 +49,7 @@
                                 @if (!Model.Flags.Any())
                                 {
                                     <tr>
-                                        <td colspan="6" class="text-center py-5">
+                                        <td colspan="7" class="text-center py-5">
                                             <div class="py-4 text-muted">
                                                 <i class="bi bi-flag fs-2 d-block mb-3"></i>
                                                 <h5>No feature flags found</h5>
@@ -81,6 +85,20 @@
                                                        @(!flag.IsEnabled ? "disabled" : "")>
                                                     <span class="rollout-value badge bg-secondary">@flag.RolloutPercentage%</span>
                                                 </div>
+                                            </td>
+                                            <td class="text-center">
+                                                @if (flag.TargetingRuleGroups?.Any() == true)
+                                                {
+                                                    <a href="@Url.Page("/TargetingRules", new { flagId = flag.Id })" class="btn btn-sm btn-outline-success" title="@flag.TargetingRuleGroups.Count group(s), @flag.TargetingRuleGroups.Sum(g => g.Rules?.Count ?? 0) rule(s)">
+                                                        <i class="bi bi-target me-1"></i>@flag.TargetingRuleGroups.Count
+                                                    </a>
+                                                }
+                                                else
+                                                {
+                                                    <a href="@Url.Page("/TargetingRules", new { flagId = flag.Id })" class="text-muted text-decoration-none" title="No targeting rules configured">
+                                                        <i class="bi bi-dash-circle"></i>
+                                                    </a>
+                                                }
                                             </td>
                                             <td>
                                                 <span class="text-muted small">

--- a/src/ToggleNet.Dashboard/Pages/TargetingRules.cshtml
+++ b/src/ToggleNet.Dashboard/Pages/TargetingRules.cshtml
@@ -1,0 +1,280 @@
+@page "/targeting-rules"
+@model ToggleNet.Dashboard.Pages.TargetingRulesModel
+@{
+    ViewData["Title"] = "Targeting Rules";
+    Layout = "_Layout";
+}
+
+<div class="container py-4">
+    <div class="d-flex justify-content-between align-items-center mb-4">
+        <div>
+            <h1 class="mb-1">Targeting Rules</h1>
+            <p class="text-muted">Advanced targeting configuration for feature flags</p>
+        </div>
+        <div>
+            <a href="@Url.Page("/Index")" class="btn btn-outline-secondary me-2">
+                <i class="bi bi-arrow-left me-2"></i>Back to Flags
+            </a>
+        </div>
+    </div>
+
+    <form id="antiforgeryForm" class="d-none">
+        @Html.AntiForgeryToken()
+    </form>
+
+    <!-- Feature Flag Selection -->
+    <div class="row mb-4">
+        <div class="col-md-6">
+            <div class="card shadow-sm border-0">
+                <div class="card-header bg-white py-3">
+                    <h5 class="mb-0">Select Feature Flag</h5>
+                </div>
+                <div class="card-body">
+                    <div class="mb-3">
+                        <label for="flagSelect" class="form-label">Feature Flag</label>
+                        <select id="flagSelect" class="form-select" onchange="loadTargetingRules()">
+                            <option value="">Select a feature flag...</option>
+                            @foreach (var flag in Model.Flags)
+                            {
+                                <option value="@flag.Id" data-name="@flag.Name">@flag.Name - @flag.Description</option>
+                            }
+                        </select>
+                    </div>
+                    
+                    <div id="flagInfo" class="d-none">
+                        <div class="row">
+                            <div class="col-sm-6">
+                                <div class="form-check form-switch">
+                                    <input class="form-check-input" type="checkbox" id="useTargetingRules" onchange="toggleTargetingRules()">
+                                    <label class="form-check-label" for="useTargetingRules">
+                                        Use Targeting Rules
+                                    </label>
+                                </div>
+                                <small class="text-muted">Enable advanced targeting for this flag</small>
+                            </div>
+                            <div class="col-sm-6">
+                                <label for="fallbackPercentage" class="form-label">Fallback Rollout %</label>
+                                <input type="number" class="form-control" id="fallbackPercentage" min="0" max="100" value="0">
+                                <small class="text-muted">Used when no targeting rules match</small>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Targeting Rules Configuration -->
+    <div id="targetingRulesSection" class="d-none">
+        <div class="card shadow-sm border-0">
+            <div class="card-header bg-white py-3 d-flex justify-content-between align-items-center">
+                <h5 class="mb-0">Targeting Rule Groups</h5>
+                <button type="button" class="btn btn-success btn-sm" onclick="addRuleGroup()">
+                    <i class="bi bi-plus-circle me-2"></i>Add Rule Group
+                </button>
+            </div>
+            <div class="card-body">
+                <div id="ruleGroupsContainer">
+                    <div class="text-center py-5 text-muted">
+                        <i class="bi bi-target fs-2 d-block mb-3"></i>
+                        <p>No targeting rule groups configured.</p>
+                        <p class="small">Add a rule group to start targeting specific users based on their attributes.</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Rule Group Template -->
+<template id="ruleGroupTemplate">
+    <div class="rule-group border rounded p-4 mb-4" data-group-id="">
+        <div class="d-flex justify-content-between align-items-center mb-3">
+            <div class="d-flex align-items-center">
+                <h6 class="mb-0 me-3">Rule Group</h6>
+                <span class="badge bg-secondary">Priority: <span class="priority-display">1</span></span>
+            </div>
+            <div class="btn-group">
+                <button type="button" class="btn btn-outline-primary btn-sm" onclick="addRule(this)">
+                    <i class="bi bi-plus me-1"></i>Add Rule
+                </button>
+                <button type="button" class="btn btn-outline-danger btn-sm" onclick="removeRuleGroup(this)">
+                    <i class="bi bi-trash"></i>
+                </button>
+            </div>
+        </div>
+
+        <div class="row mb-3">
+            <div class="col-md-3">
+                <label class="form-label">Group Name</label>
+                <input type="text" class="form-control group-name" placeholder="e.g., Premium Users">
+            </div>
+            <div class="col-md-2">
+                <label class="form-label">Logic</label>
+                <select class="form-select group-logic">
+                    <option value="And">AND</option>
+                    <option value="Or">OR</option>
+                </select>
+            </div>
+            <div class="col-md-2">
+                <label class="form-label">Priority</label>
+                <input type="number" class="form-control group-priority" min="1" value="1" onchange="updatePriorityDisplay(this)">
+            </div>
+            <div class="col-md-2">
+                <label class="form-label">Rollout %</label>
+                <input type="number" class="form-control group-rollout" min="0" max="100" value="100">
+            </div>
+            <div class="col-md-3">
+                <label class="form-label">Status</label>
+                <div class="form-check form-switch mt-2">
+                    <input class="form-check-input group-enabled" type="checkbox" checked>
+                    <label class="form-check-label">Enabled</label>
+                </div>
+            </div>
+        </div>
+
+        <div class="rules-container">
+            <!-- Rules will be added here -->
+        </div>
+    </div>
+</template>
+
+<!-- Rule Template -->
+<template id="ruleTemplate">
+    <div class="rule border-start border-3 border-info ps-3 mb-3" data-rule-id="">
+        <div class="d-flex justify-content-between align-items-center mb-2">
+            <h6 class="mb-0">Rule</h6>
+            <button type="button" class="btn btn-outline-danger btn-sm" onclick="removeRule(this)">
+                <i class="bi bi-trash"></i>
+            </button>
+        </div>
+
+        <div class="row">
+            <div class="col-md-3">
+                <label class="form-label">Rule Name</label>
+                <input type="text" class="form-control rule-name" placeholder="e.g., Country Check">
+            </div>
+            <div class="col-md-2">
+                <label class="form-label">Attribute</label>
+                <input type="text" class="form-control rule-attribute" placeholder="e.g., country" list="commonAttributes">
+            </div>
+            <div class="col-md-2">
+                <label class="form-label">Operator</label>
+                <select class="form-select rule-operator">
+                    <option value="Equals">Equals</option>
+                    <option value="EqualsIgnoreCase">Equals (ignore case)</option>
+                    <option value="NotEquals">Not Equals</option>
+                    <option value="In">In List</option>
+                    <option value="NotIn">Not In List</option>
+                    <option value="Contains">Contains</option>
+                    <option value="NotContains">Not Contains</option>
+                    <option value="StartsWith">Starts With</option>
+                    <option value="EndsWith">Ends With</option>
+                    <option value="Regex">Regex Match</option>
+                    <option value="GreaterThan">Greater Than</option>
+                    <option value="GreaterThanOrEqual">Greater Than or Equal</option>
+                    <option value="LessThan">Less Than</option>
+                    <option value="LessThanOrEqual">Less Than or Equal</option>
+                    <option value="Before">Before (Date)</option>
+                    <option value="After">After (Date)</option>
+                    <option value="VersionGreaterThan">Version Greater Than</option>
+                    <option value="VersionLessThan">Version Less Than</option>
+                </select>
+            </div>
+            <div class="col-md-3">
+                <label class="form-label">Value</label>
+                <input type="text" class="form-control rule-value" placeholder="e.g., US or [&quot;US&quot;,&quot;CA&quot;]">
+            </div>
+            <div class="col-md-2">
+                <label class="form-label">Priority</label>
+                <input type="number" class="form-control rule-priority" min="1" value="1">
+            </div>
+        </div>
+
+        <div class="mt-2">
+            <div class="form-check form-switch">
+                <input class="form-check-input rule-enabled" type="checkbox" checked>
+                <label class="form-check-label">Enabled</label>
+            </div>
+        </div>
+    </div>
+</template>
+
+<!-- Common Attributes Datalist -->
+<datalist id="commonAttributes">
+    <option value="country"></option>
+    <option value="region"></option>
+    <option value="city"></option>
+    <option value="userType"></option>
+    <option value="plan"></option>
+    <option value="deviceType"></option>
+    <option value="osVersion"></option>
+    <option value="appVersion"></option>
+    <option value="age"></option>
+    <option value="registrationDate"></option>
+    <option value="companySize"></option>
+    <option value="industry"></option>
+    <option value="email"></option>
+    <option value="betaTester"></option>
+    <option value="language"></option>
+    <option value="timezone"></option>
+</datalist>
+
+<!-- Save/Test Section -->
+<div id="actionSection" class="d-none">
+    <div class="card shadow-sm border-0 mt-4">
+        <div class="card-body">
+            <div class="d-flex justify-content-between align-items-center">
+                <div>
+                    <h6 class="mb-1">Actions</h6>
+                    <small class="text-muted">Save your targeting rules or test them with sample user data</small>
+                </div>
+                <div class="btn-group">
+                    <button type="button" class="btn btn-outline-info" onclick="testTargetingRules()">
+                        <i class="bi bi-play-circle me-2"></i>Test Rules
+                    </button>
+                    <button type="button" class="btn btn-primary" onclick="saveTargetingRules()">
+                        <i class="bi bi-save me-2"></i>Save Configuration
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<style>
+.rule-group {
+    background-color: #f8f9fa;
+}
+
+.rule {
+    background-color: white;
+    border-radius: 0.375rem;
+    padding: 1rem;
+}
+
+.priority-display {
+    font-weight: bold;
+}
+
+.bi {
+    font-size: 1.1em;
+}
+</style>
+
+<script src="~/js/targeting-rules.js"></script>
+
+@if (!string.IsNullOrEmpty(Model.SelectedFlagId))
+{
+    <script>
+        document.addEventListener('DOMContentLoaded', function() {
+            // Pre-select the flag if flagId is provided in query parameter
+            const flagSelect = document.getElementById('flagSelect');
+            if (flagSelect) {
+                flagSelect.value = '@Model.SelectedFlagId';
+                // Trigger the load function
+                loadTargetingRules();
+            }
+        });
+    </script>
+}

--- a/src/ToggleNet.Dashboard/Pages/TargetingRules.cshtml.cs
+++ b/src/ToggleNet.Dashboard/Pages/TargetingRules.cshtml.cs
@@ -1,0 +1,296 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using ToggleNet.Core;
+using ToggleNet.Core.Entities;
+using ToggleNet.Core.Storage;
+using ToggleNet.Core.Targeting;
+using System.Text.Json;
+
+namespace ToggleNet.Dashboard.Pages
+{
+    public class TargetingRulesModel : PageModel
+    {
+        private readonly FeatureFlagManager _flagManager;
+        private readonly IFeatureStore _featureStore;
+        private readonly ITargetingRulesEngine _targetingEngine;
+        private readonly ILogger<TargetingRulesModel> _logger;
+
+        public TargetingRulesModel(
+            FeatureFlagManager flagManager, 
+            IFeatureStore featureStore,
+            ITargetingRulesEngine targetingEngine,
+            ILogger<TargetingRulesModel> logger)
+        {
+            _flagManager = flagManager;
+            _featureStore = featureStore;
+            _targetingEngine = targetingEngine;
+            _logger = logger;
+        }
+
+        [BindProperty]
+        public IEnumerable<FeatureFlag> Flags { get; set; } = Array.Empty<FeatureFlag>();
+        
+        public string Environment { get; set; } = string.Empty;
+        public string SelectedFlagId { get; set; } = string.Empty;
+
+        public async Task OnGetAsync(string flagId = null)
+        {
+            // Get the current environment from the flag manager through reflection
+            var fieldInfo = _flagManager.GetType().GetField("_environment", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            Environment = (string)fieldInfo?.GetValue(_flagManager)!;
+            
+            // Get all flags
+            Flags = await _flagManager.GetAllFlagsAsync();
+            
+            // Set the selected flag ID if provided
+            SelectedFlagId = flagId ?? string.Empty;
+        }
+
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> OnPostGetTargetingRulesAsync([FromBody] GetTargetingRulesRequest request)
+        {
+            try
+            {
+                if (!Guid.TryParse(request.FeatureFlagId, out var flagId))
+                {
+                    return BadRequest("Invalid feature flag ID");
+                }
+
+                // Load all flags and find the specific one
+                var allFlags = await _flagManager.GetAllFlagsAsync();
+                var flag = allFlags.FirstOrDefault(f => f.Id == flagId);
+                if (flag == null)
+                {
+                    return NotFound("Feature flag not found");
+                }
+
+                var ruleGroups = await _featureStore.GetTargetingRuleGroupsAsync(flagId);
+
+                return new JsonResult(new
+                {
+                    featureFlag = new
+                    {
+                        flag.Id,
+                        flag.Name,
+                        useTargetingRules = flag.UseTargetingRules,
+                        rolloutPercentage = flag.RolloutPercentage
+                    },
+                    ruleGroups = ruleGroups.Select(rg => new
+                    {
+                        rg.Id,
+                        rg.Name,
+                        logicalOperator = rg.LogicalOperator.ToString(),
+                        rg.Priority,
+                        rolloutPercentage = rg.RolloutPercentage,
+                        isEnabled = true, // Add this property that JavaScript expects
+                        rules = rg.Rules?.Select(r => new
+                        {
+                            r.Id,
+                            r.Name,
+                            attribute = r.Attribute,
+                            @operator = r.Operator.ToString(),
+                            r.Value,
+                            r.Priority,
+                            isEnabled = true // Add this property that JavaScript expects
+                        }) ?? Enumerable.Empty<object>()
+                    })
+                });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error getting targeting rules for flag {FlagId}", request.FeatureFlagId);
+                return StatusCode(500, "Internal server error");
+            }
+        }
+
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> OnPostSaveTargetingRulesAsync([FromBody] SaveTargetingRulesRequest request)
+        {
+            try
+            {
+                if (!Guid.TryParse(request.FeatureFlagId, out var flagId))
+                {
+                    return BadRequest("Invalid feature flag ID");
+                }
+
+                // Update flag's UseTargetingRules property and fallback percentage
+                await _featureStore.UpdateFlagTargetingAsync(flagId, request.UseTargetingRules);
+                
+                // Update the flag's rollout percentage (fallback percentage)
+                var allFlags = await _flagManager.GetAllFlagsAsync();
+                var flag = allFlags.FirstOrDefault(f => f.Id == flagId);
+                if (flag != null)
+                {
+                    flag.RolloutPercentage = request.FallbackPercentage;
+                    await _featureStore.SetFlagAsync(flag);
+                }
+
+                // Clear existing rule groups
+                await _featureStore.ClearTargetingRuleGroupsAsync(flagId);
+
+                // Add new rule groups if targeting is enabled
+                if (request.UseTargetingRules && request.RuleGroups?.Any() == true)
+                {
+                    foreach (var groupRequest in request.RuleGroups)
+                    {
+                        var ruleGroup = new TargetingRuleGroup
+                        {
+                            Id = Guid.NewGuid(),
+                            FeatureFlagId = flagId,
+                            Name = groupRequest.Name,
+                            LogicalOperator = Enum.Parse<LogicalOperator>(groupRequest.LogicalOperator, true),
+                            Priority = groupRequest.Priority,
+                            RolloutPercentage = groupRequest.RolloutPercentage,
+                            Rules = groupRequest.Rules?.Select(r => new TargetingRule
+                            {
+                                Id = Guid.NewGuid(),
+                                Name = r.Name,
+                                Attribute = r.Attribute,
+                                Operator = Enum.Parse<TargetingOperator>(r.Operator, true),
+                                Value = r.Value,
+                                Priority = r.Priority
+                            }).ToList() ?? new List<TargetingRule>()
+                        };
+
+                        await _featureStore.CreateTargetingRuleGroupAsync(ruleGroup);
+                    }
+                }
+
+                return new JsonResult(new { success = true });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error saving targeting rules for flag {FlagId}", request.FeatureFlagId);
+                return StatusCode(500, "Internal server error");
+            }
+        }
+
+        [ValidateAntiForgeryToken]
+        public async Task<IActionResult> OnPostTestTargetingRulesAsync([FromBody] TestTargetingRulesRequest request)
+        {
+            try
+            {
+                if (!Guid.TryParse(request.FeatureFlagId, out var flagId))
+                {
+                    return BadRequest("Invalid feature flag ID");
+                }
+
+                // Load all flags and find the specific one (same as in OnPostGetTargetingRulesAsync)
+                var allFlags = await _flagManager.GetAllFlagsAsync();
+                var flag = allFlags.FirstOrDefault(f => f.Id == flagId);
+                if (flag == null)
+                {
+                    return NotFound("Feature flag not found");
+                }
+
+                // Create user context from test data
+                var userContext = new UserContext
+                {
+                    UserId = request.UserId,
+                    Attributes = request.UserAttributes ?? new Dictionary<string, object>()
+                };
+
+                // Test against current targeting rules
+                var ruleGroups = await _featureStore.GetTargetingRuleGroupsAsync(flagId);
+                var testFlag = new FeatureFlag
+                {
+                    Id = flag.Id,
+                    Name = flag.Name,
+                    IsEnabled = flag.IsEnabled,
+                    RolloutPercentage = flag.RolloutPercentage,
+                    UseTargetingRules = request.UseTargetingRules,
+                    TargetingRuleGroups = ruleGroups.ToList()
+                };
+
+                // If we're testing new rules, use those instead
+                if (request.UseTargetingRules && request.RuleGroups?.Any() == true)
+                {
+                    testFlag.TargetingRuleGroups = request.RuleGroups.Select(groupRequest => new TargetingRuleGroup
+                    {
+                        Name = groupRequest.Name,
+                        LogicalOperator = Enum.Parse<LogicalOperator>(groupRequest.LogicalOperator, true),
+                        Priority = groupRequest.Priority,
+                        RolloutPercentage = groupRequest.RolloutPercentage,
+                        Rules = groupRequest.Rules?.Select(r => new TargetingRule
+                        {
+                            Name = r.Name,
+                            Attribute = r.Attribute,
+                            Operator = Enum.Parse<TargetingOperator>(r.Operator, true),
+                            Value = r.Value,
+                            Priority = r.Priority
+                        }).ToList() ?? new List<TargetingRule>()
+                    }).ToList();
+                }
+
+                var result = await _targetingEngine.EvaluateAsync(testFlag, userContext);
+
+                return new JsonResult(new
+                {
+                    success = true,
+                    result = new
+                    {
+                        isEnabled = result,
+                        reason = "Evaluation completed",
+                        matchedRuleGroup = "N/A",
+                        evaluationDetails = "Basic evaluation result"
+                    }
+                });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error testing targeting rules for flag {FlagId}", request.FeatureFlagId);
+                return StatusCode(500, "Internal server error");
+            }
+        }
+
+        public class GetTargetingRulesRequest
+        {
+            public string FeatureFlagId { get; set; } = string.Empty;
+        }
+
+        public class SaveTargetingRulesRequest
+        {
+            public string FeatureFlagId { get; set; } = string.Empty;
+            public bool UseTargetingRules { get; set; }
+            public int FallbackPercentage { get; set; }
+            public List<RuleGroupRequest> RuleGroups { get; set; } = new();
+        }
+
+        public class RuleGroupRequest
+        {
+            public string Id { get; set; } = string.Empty;
+            public string Name { get; set; } = string.Empty;
+            public string LogicalOperator { get; set; } = string.Empty;
+            public int Priority { get; set; }
+            public int RolloutPercentage { get; set; }
+            public bool IsEnabled { get; set; } = true;
+            public List<RuleRequest> Rules { get; set; } = new();
+        }
+
+        public class RuleRequest
+        {
+            public string Id { get; set; } = string.Empty;
+            public string Name { get; set; } = string.Empty;
+            public string Attribute { get; set; } = string.Empty;
+            public string Operator { get; set; } = string.Empty;
+            public string Value { get; set; } = string.Empty;
+            public int Priority { get; set; }
+            public bool IsEnabled { get; set; } = true;
+        }
+
+        public class TestTargetingRulesRequest
+        {
+            public string FeatureFlagId { get; set; } = string.Empty;
+            public string UserId { get; set; } = string.Empty;
+            public Dictionary<string, object> UserAttributes { get; set; } = new();
+            public bool UseTargetingRules { get; set; }
+            public List<RuleGroupRequest> RuleGroups { get; set; } = new();
+        }
+    }
+}

--- a/src/ToggleNet.Dashboard/Pages/_Layout.cshtml
+++ b/src/ToggleNet.Dashboard/Pages/_Layout.cshtml
@@ -11,7 +11,7 @@
 <body>
     <nav class="navbar navbar-expand-lg navbar-dark bg-primary shadow-sm">
         <div class="container">
-            <a class="navbar-brand d-flex align-items-center" href="~/">
+            <a class="navbar-brand d-flex align-items-center" href="@Url.Page("/Index")">
                 <i class="bi bi-toggles me-2 fs-4"></i>
                 <span class="fw-bold">ToggleNet</span>
             </a>
@@ -21,17 +21,22 @@
             <div class="collapse navbar-collapse" id="navbarNav">
                 <ul class="navbar-nav me-auto">
                     <li class="nav-item">
-                        <a class="nav-link @(ViewData["Title"]?.ToString() == "Feature Flags Dashboard" ? "active" : "")" href="~/">Feature Flags</a>
+                        <a class="nav-link @(ViewData["Title"]?.ToString() == "Feature Flags Dashboard" ? "active" : "")" href="@Url.Page("/Index")">Feature Flags</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link @(ViewData["Title"]?.ToString() == "Feature Analytics" ? "active" : "")" href="~/analytics">
+                        <a class="nav-link @(ViewData["Title"]?.ToString() == "Targeting Rules" ? "active" : "")" href="@Url.Page("/TargetingRules")">
+                            <i class="bi bi-target me-1"></i> Targeting Rules
+                        </a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link @(ViewData["Title"]?.ToString() == "Feature Analytics" ? "active" : "")" href="@Url.Page("/Analytics")">
                             <i class="bi bi-graph-up me-1"></i> Analytics
                         </a>
                     </li>
                     @if (User.IsInRole("Admin"))
                     {
                         <li class="nav-item">
-                            <a class="nav-link @(ViewData["Title"]?.ToString() == "Manage Users" ? "active" : "")" href="~/manageusers">Manage Users</a>
+                            <a class="nav-link @(ViewData["Title"]?.ToString() == "Manage Users" ? "active" : "")" href="@Url.Page("/ManageUsers")">Manage Users</a>
                         </li>
                     }
                 </ul>
@@ -43,7 +48,7 @@
                                 @User.Identity.Name
                             </a>
                             <ul class="dropdown-menu dropdown-menu-end">
-                                <li><a class="dropdown-item" href="~/logout">Logout</a></li>
+                                <li><a class="dropdown-item" href="@Url.Page("/Logout")">Logout</a></li>
                             </ul>
                         </li>
                     }

--- a/src/ToggleNet.Dashboard/ToggleNet.Dashboard.csproj
+++ b/src/ToggleNet.Dashboard/ToggleNet.Dashboard.csproj
@@ -23,4 +23,8 @@
     <ProjectReference Include="..\ToggleNet.Core\ToggleNet.Core.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <EmbeddedResource Include="wwwroot\**\*" />
+  </ItemGroup>
+
 </Project>

--- a/src/ToggleNet.Dashboard/wwwroot/js/targeting-rules.js
+++ b/src/ToggleNet.Dashboard/wwwroot/js/targeting-rules.js
@@ -1,0 +1,430 @@
+// Targeting Rules Dashboard JavaScript
+
+let currentFeatureFlagId = null;
+let ruleGroupCounter = 0;
+let ruleCounter = 0;
+
+// Initialize the page
+document.addEventListener('DOMContentLoaded', function() {
+    // Any initialization code
+});
+
+// Load targeting rules for selected flag
+async function loadTargetingRules() {
+    const flagSelect = document.getElementById('flagSelect');
+    const selectedOption = flagSelect.options[flagSelect.selectedIndex];
+    
+    if (!selectedOption.value) {
+        hideTargetingRulesSection();
+        return;
+    }
+    
+    currentFeatureFlagId = selectedOption.value;
+    const flagName = selectedOption.dataset.name;
+    
+    try {
+        const response = await fetch('?handler=GetTargetingRules', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRF-TOKEN': getAntiForgeryToken()
+            },
+            body: JSON.stringify({ FeatureFlagId: currentFeatureFlagId })
+        });
+        
+        if (response.ok) {
+            const data = await response.json();
+            populateTargetingRules(data);
+            showTargetingRulesSection();
+        } else {
+            console.error('Error loading targeting rules:', response.statusText);
+            showAlert('Error loading targeting rules', 'danger');
+        }
+    } catch (error) {
+        console.error('Error loading targeting rules:', error);
+        showAlert('Error loading targeting rules', 'danger');
+    }
+}
+
+// Show targeting rules section
+function showTargetingRulesSection() {
+    document.getElementById('flagInfo').classList.remove('d-none');
+    document.getElementById('targetingRulesSection').classList.remove('d-none');
+    document.getElementById('actionSection').classList.remove('d-none');
+}
+
+// Hide targeting rules section
+function hideTargetingRulesSection() {
+    document.getElementById('flagInfo').classList.add('d-none');
+    document.getElementById('targetingRulesSection').classList.add('d-none');
+    document.getElementById('actionSection').classList.add('d-none');
+    currentFeatureFlagId = null;
+}
+
+// Populate targeting rules from server data
+function populateTargetingRules(data) {
+    // Set flag info
+    document.getElementById('useTargetingRules').checked = data.featureFlag.useTargetingRules;
+    document.getElementById('fallbackPercentage').value = data.featureFlag.rolloutPercentage;
+    
+    // Clear existing rule groups
+    const container = document.getElementById('ruleGroupsContainer');
+    container.innerHTML = '';
+    
+    if (data.ruleGroups && data.ruleGroups.length > 0) {
+        data.ruleGroups.forEach(ruleGroup => {
+            addRuleGroup(ruleGroup);
+        });
+        toggleTargetingRulesDisplay();
+    } else {
+        showEmptyState();
+    }
+}
+
+// Toggle targeting rules display
+function toggleTargetingRules() {
+    toggleTargetingRulesDisplay();
+}
+
+function toggleTargetingRulesDisplay() {
+    const useTargetingRules = document.getElementById('useTargetingRules').checked;
+    const container = document.getElementById('ruleGroupsContainer');
+    
+    if (!useTargetingRules) {
+        showEmptyState();
+    } else if (container.children.length === 0 || container.querySelector('.text-center')) {
+        // Show empty state but allow adding rule groups
+        showEmptyState();
+    }
+}
+
+function showEmptyState() {
+    const container = document.getElementById('ruleGroupsContainer');
+    container.innerHTML = `
+        <div class="text-center py-5 text-muted">
+            <i class="bi bi-target fs-2 d-block mb-3"></i>
+            <p>No targeting rule groups configured.</p>
+            <p class="small">Add a rule group to start targeting specific users based on their attributes.</p>
+        </div>
+    `;
+}
+
+// Add new rule group
+function addRuleGroup(existingData = null) {
+    const container = document.getElementById('ruleGroupsContainer');
+    
+    // Remove empty state if present
+    if (container.querySelector('.text-center')) {
+        container.innerHTML = '';
+    }
+    
+    const template = document.getElementById('ruleGroupTemplate');
+    const clone = template.content.cloneNode(true);
+    
+    ruleGroupCounter++;
+    const groupId = existingData?.id || `group-${ruleGroupCounter}`;
+    
+    // Set group data
+    const groupElement = clone.querySelector('.rule-group');
+    groupElement.dataset.groupId = groupId;
+    
+    if (existingData) {
+        clone.querySelector('.group-name').value = existingData.name || '';
+        clone.querySelector('.group-logic').value = existingData.logicalOperator || 'And';
+        clone.querySelector('.group-priority').value = existingData.priority || 1;
+        clone.querySelector('.group-rollout').value = existingData.rolloutPercentage || 100;
+        clone.querySelector('.group-enabled').checked = existingData.isEnabled !== false;
+        clone.querySelector('.priority-display').textContent = existingData.priority || 1;
+    }
+    
+    container.appendChild(clone);
+    
+    // Add existing rules
+    if (existingData?.rules) {
+        const rulesContainer = container.querySelector(`[data-group-id="${groupId}"] .rules-container`);
+        existingData.rules.forEach(rule => {
+            addRuleToGroup(rulesContainer, rule);
+        });
+    }
+}
+
+// Add rule to specific group
+function addRule(button) {
+    const ruleGroup = button.closest('.rule-group');
+    const rulesContainer = ruleGroup.querySelector('.rules-container');
+    addRuleToGroup(rulesContainer);
+}
+
+function addRuleToGroup(container, existingData = null) {
+    const template = document.getElementById('ruleTemplate');
+    const clone = template.content.cloneNode(true);
+    
+    ruleCounter++;
+    const ruleId = existingData?.id || `rule-${ruleCounter}`;
+    
+    const ruleElement = clone.querySelector('.rule');
+    ruleElement.dataset.ruleId = ruleId;
+    
+    if (existingData) {
+        clone.querySelector('.rule-name').value = existingData.name || '';
+        clone.querySelector('.rule-attribute').value = existingData.attribute || '';
+        clone.querySelector('.rule-operator').value = existingData.operator || 'Equals';
+        clone.querySelector('.rule-value').value = existingData.value || '';
+        clone.querySelector('.rule-priority').value = existingData.priority || 1;
+        clone.querySelector('.rule-enabled').checked = existingData.isEnabled !== false;
+    }
+    
+    container.appendChild(clone);
+}
+
+// Remove rule group
+function removeRuleGroup(button) {
+    const ruleGroup = button.closest('.rule-group');
+    ruleGroup.remove();
+    
+    // Show empty state if no groups left
+    const container = document.getElementById('ruleGroupsContainer');
+    if (container.children.length === 0) {
+        showEmptyState();
+    }
+}
+
+// Remove rule
+function removeRule(button) {
+    const rule = button.closest('.rule');
+    rule.remove();
+}
+
+// Update priority display
+function updatePriorityDisplay(input) {
+    const ruleGroup = input.closest('.rule-group');
+    const display = ruleGroup.querySelector('.priority-display');
+    display.textContent = input.value;
+}
+
+// Save targeting rules
+async function saveTargetingRules() {
+    if (!currentFeatureFlagId) {
+        showAlert('Please select a feature flag first', 'warning');
+        return;
+    }
+    
+    const data = collectTargetingRulesData();
+    
+    try {
+        const response = await fetch('?handler=SaveTargetingRules', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRF-TOKEN': getAntiForgeryToken()
+            },
+            body: JSON.stringify(data)
+        });
+        
+        if (response.ok) {
+            const result = await response.json();
+            showAlert(result.message || 'Targeting rules saved successfully', 'success');
+        } else {
+            const error = await response.text();
+            showAlert('Error saving targeting rules: ' + error, 'danger');
+        }
+    } catch (error) {
+        console.error('Error saving targeting rules:', error);
+        showAlert('Error saving targeting rules', 'danger');
+    }
+}
+
+// Test targeting rules
+async function testTargetingRules() {
+    if (!currentFeatureFlagId) {
+        showAlert('Please select a feature flag first', 'warning');
+        return;
+    }
+    
+    // Show test modal
+    showTestModal();
+}
+
+function showTestModal() {
+    // Create test modal dynamically
+    const modalHtml = `
+        <div class="modal fade" id="testModal" tabindex="-1">
+            <div class="modal-dialog modal-lg">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title">Test Targeting Rules</h5>
+                        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                    </div>
+                    <div class="modal-body">
+                        <div class="mb-3">
+                            <label class="form-label">Test User ID</label>
+                            <input type="text" id="testUserId" class="form-control" value="test-user-123">
+                        </div>
+                        <div class="mb-3">
+                            <label class="form-label">User Attributes (JSON)</label>
+                            <textarea id="testAttributes" class="form-control" rows="8">{
+  "country": "US",
+  "userType": "premium",
+  "age": 28,
+  "deviceType": "mobile",
+  "appVersion": "2.1.0",
+  "plan": "enterprise",
+  "registrationDate": "2023-01-15"
+}</textarea>
+                        </div>
+                        <div id="testResult" class="d-none"></div>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+                        <button type="button" class="btn btn-primary" onclick="executeTest()">Run Test</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    `;
+    
+    // Remove existing modal if present
+    const existingModal = document.getElementById('testModal');
+    if (existingModal) {
+        existingModal.remove();
+    }
+    
+    // Add modal to DOM
+    document.body.insertAdjacentHTML('beforeend', modalHtml);
+    
+    // Show modal
+    const modal = new bootstrap.Modal(document.getElementById('testModal'));
+    modal.show();
+}
+
+async function executeTest() {
+    const testUserId = document.getElementById('testUserId').value;
+    const testAttributesText = document.getElementById('testAttributes').value;
+    
+    let testAttributes;
+    try {
+        testAttributes = JSON.parse(testAttributesText);
+    } catch (error) {
+        showAlert('Invalid JSON in test attributes', 'danger');
+        return;
+    }
+    
+    const data = collectTargetingRulesData();
+    data.UserId = testUserId;
+    data.UserAttributes = testAttributes;
+    
+    try {
+        const response = await fetch('?handler=TestTargetingRules', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRF-TOKEN': getAntiForgeryToken()
+            },
+            body: JSON.stringify(data)
+        });
+        
+        if (response.ok) {
+            const result = await response.json();
+            displayTestResult(result);
+        } else {
+            const error = await response.text();
+            showAlert('Error testing targeting rules: ' + error, 'danger');
+        }
+    } catch (error) {
+        console.error('Error testing targeting rules:', error);
+        showAlert('Error testing targeting rules', 'danger');
+    }
+}
+
+function displayTestResult(result) {
+    const resultDiv = document.getElementById('testResult');
+    const alertClass = result.result ? 'alert-success' : 'alert-warning';
+    const icon = result.result ? 'check-circle' : 'x-circle';
+    
+    resultDiv.innerHTML = `
+        <div class="alert ${alertClass}">
+            <i class="bi bi-${icon} me-2"></i>
+            <strong>Test Result:</strong> ${result.message}
+        </div>
+        <div class="small text-muted">
+            <strong>User Context:</strong><br>
+            User ID: ${result.userContext.userId}<br>
+            Attributes: ${JSON.stringify(result.userContext.attributes, null, 2)}
+        </div>
+    `;
+    
+    resultDiv.classList.remove('d-none');
+}
+
+// Collect targeting rules data from form
+function collectTargetingRulesData() {
+    const useTargetingRules = document.getElementById('useTargetingRules').checked;
+    const fallbackPercentage = parseInt(document.getElementById('fallbackPercentage').value) || 0;
+    
+    const ruleGroups = [];
+    
+    if (useTargetingRules) {
+        document.querySelectorAll('.rule-group').forEach(groupElement => {
+            const groupData = {
+                Id: groupElement.dataset.groupId,
+                Name: groupElement.querySelector('.group-name').value,
+                LogicalOperator: groupElement.querySelector('.group-logic').value,
+                Priority: parseInt(groupElement.querySelector('.group-priority').value) || 1,
+                RolloutPercentage: parseInt(groupElement.querySelector('.group-rollout').value) || 100,
+                IsEnabled: groupElement.querySelector('.group-enabled').checked,
+                Rules: []
+            };
+            
+            groupElement.querySelectorAll('.rule').forEach(ruleElement => {
+                const ruleData = {
+                    Id: ruleElement.dataset.ruleId,
+                    Name: ruleElement.querySelector('.rule-name').value,
+                    Attribute: ruleElement.querySelector('.rule-attribute').value,
+                    Operator: ruleElement.querySelector('.rule-operator').value,
+                    Value: ruleElement.querySelector('.rule-value').value,
+                    Priority: parseInt(ruleElement.querySelector('.rule-priority').value) || 1,
+                    IsEnabled: ruleElement.querySelector('.rule-enabled').checked
+                };
+                
+                groupData.Rules.push(ruleData);
+            });
+            
+            ruleGroups.push(groupData);
+        });
+    }
+    
+    return {
+        FeatureFlagId: currentFeatureFlagId,
+        UseTargetingRules: useTargetingRules,
+        FallbackPercentage: fallbackPercentage,
+        RuleGroups: ruleGroups
+    };
+}
+
+// Utility functions
+function getAntiForgeryToken() {
+    const token = document.querySelector('input[name="__RequestVerificationToken"]');
+    return token ? token.value : '';
+}
+
+function showAlert(message, type = 'info') {
+    // Create alert element
+    const alertHtml = `
+        <div class="alert alert-${type} alert-dismissible fade show" role="alert">
+            ${message}
+            <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+        </div>
+    `;
+    
+    // Find container (preferably at top of main content)
+    const container = document.querySelector('.container');
+    container.insertAdjacentHTML('afterbegin', alertHtml);
+    
+    // Auto-dismiss after 5 seconds
+    setTimeout(() => {
+        const alert = container.querySelector('.alert');
+        if (alert) {
+            alert.remove();
+        }
+    }, 5000);
+}

--- a/tests/ToggleNet.Core.Tests/FeatureFlagManagerTests.cs
+++ b/tests/ToggleNet.Core.Tests/FeatureFlagManagerTests.cs
@@ -2,6 +2,7 @@ using System.Threading.Tasks;
 using ToggleNet.Core;
 using ToggleNet.Core.Entities;
 using ToggleNet.Core.Storage;
+using ToggleNet.Core.Targeting;
 using Xunit;
 using Moq;
 using System.Collections.Generic;

--- a/tests/ToggleNet.Core.Tests/TargetingRulesEngineTests.cs
+++ b/tests/ToggleNet.Core.Tests/TargetingRulesEngineTests.cs
@@ -1,0 +1,351 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using ToggleNet.Core.Entities;
+using ToggleNet.Core.Targeting;
+using Xunit;
+
+namespace ToggleNet.Core.Tests
+{
+    public class TargetingRulesEngineTests
+    {
+        private readonly TargetingRulesEngine _engine;
+
+        public TargetingRulesEngineTests()
+        {
+            _engine = new TargetingRulesEngine();
+        }
+
+        [Fact]
+        public void EvaluateRule_Equals_ReturnsTrue_WhenValuesMatch()
+        {
+            // Arrange
+            var rule = new TargetingRule
+            {
+                Attribute = "country",
+                Operator = TargetingOperator.Equals,
+                Value = "US",
+                IsEnabled = true
+            };
+
+            var userContext = new UserContext
+            {
+                UserId = "user1",
+                Attributes = new Dictionary<string, object> { ["country"] = "US" }
+            };
+
+            // Act
+            var result = _engine.EvaluateRule(rule, userContext);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void EvaluateRule_In_ReturnsTrue_WhenValueInList()
+        {
+            // Arrange
+            var rule = new TargetingRule
+            {
+                Attribute = "country",
+                Operator = TargetingOperator.In,
+                Value = "[\"US\", \"CA\", \"UK\"]",
+                IsEnabled = true
+            };
+
+            var userContext = new UserContext
+            {
+                UserId = "user1",
+                Attributes = new Dictionary<string, object> { ["country"] = "CA" }
+            };
+
+            // Act
+            var result = _engine.EvaluateRule(rule, userContext);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void EvaluateRule_GreaterThan_ReturnsTrue_WhenNumericComparison()
+        {
+            // Arrange
+            var rule = new TargetingRule
+            {
+                Attribute = "age",
+                Operator = TargetingOperator.GreaterThan,
+                Value = "18",
+                IsEnabled = true
+            };
+
+            var userContext = new UserContext
+            {
+                UserId = "user1",
+                Attributes = new Dictionary<string, object> { ["age"] = 25 }
+            };
+
+            // Act
+            var result = _engine.EvaluateRule(rule, userContext);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void EvaluateRule_VersionGreaterThan_ReturnsTrue_WhenVersionComparison()
+        {
+            // Arrange
+            var rule = new TargetingRule
+            {
+                Attribute = "appVersion",
+                Operator = TargetingOperator.VersionGreaterThan,
+                Value = "2.0.0",
+                IsEnabled = true
+            };
+
+            var userContext = new UserContext
+            {
+                UserId = "user1",
+                Attributes = new Dictionary<string, object> { ["appVersion"] = "2.1.0" }
+            };
+
+            // Act
+            var result = _engine.EvaluateRule(rule, userContext);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task EvaluateRuleGroupAsync_And_ReturnsTrue_WhenAllRulesMatch()
+        {
+            // Arrange
+            var ruleGroup = new TargetingRuleGroup
+            {
+                LogicalOperator = LogicalOperator.And,
+                IsEnabled = true,
+                Rules = new List<TargetingRule>
+                {
+                    new TargetingRule
+                    {
+                        Attribute = "country",
+                        Operator = TargetingOperator.Equals,
+                        Value = "US",
+                        IsEnabled = true
+                    },
+                    new TargetingRule
+                    {
+                        Attribute = "userType",
+                        Operator = TargetingOperator.Equals,
+                        Value = "premium",
+                        IsEnabled = true
+                    }
+                }
+            };
+
+            var userContext = new UserContext
+            {
+                UserId = "user1",
+                Attributes = new Dictionary<string, object>
+                {
+                    ["country"] = "US",
+                    ["userType"] = "premium"
+                }
+            };
+
+            // Act
+            var result = await _engine.EvaluateRuleGroupAsync(ruleGroup, userContext);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task EvaluateRuleGroupAsync_Or_ReturnsTrue_WhenAnyRuleMatches()
+        {
+            // Arrange
+            var ruleGroup = new TargetingRuleGroup
+            {
+                LogicalOperator = LogicalOperator.Or,
+                IsEnabled = true,
+                Rules = new List<TargetingRule>
+                {
+                    new TargetingRule
+                    {
+                        Attribute = "country",
+                        Operator = TargetingOperator.Equals,
+                        Value = "US",
+                        IsEnabled = true
+                    },
+                    new TargetingRule
+                    {
+                        Attribute = "userType",
+                        Operator = TargetingOperator.Equals,
+                        Value = "premium",
+                        IsEnabled = true
+                    }
+                }
+            };
+
+            var userContext = new UserContext
+            {
+                UserId = "user1",
+                Attributes = new Dictionary<string, object>
+                {
+                    ["country"] = "CA", // Doesn't match first rule
+                    ["userType"] = "premium" // Matches second rule
+                }
+            };
+
+            // Act
+            var result = await _engine.EvaluateRuleGroupAsync(ruleGroup, userContext);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task EvaluateAsync_UsesTargetingRules_WhenConfigured()
+        {
+            // Arrange
+            var featureFlag = new FeatureFlag
+            {
+                Name = "test-feature",
+                IsEnabled = true,
+                Environment = "Test",
+                UseTargetingRules = true,
+                RolloutPercentage = 0, // Fallback should be 0
+                TargetingRuleGroups = new List<TargetingRuleGroup>
+                {
+                    new TargetingRuleGroup
+                    {
+                        LogicalOperator = LogicalOperator.And,
+                        IsEnabled = true,
+                        Priority = 1,
+                        RolloutPercentage = 100,
+                        Rules = new List<TargetingRule>
+                        {
+                            new TargetingRule
+                            {
+                                Attribute = "country",
+                                Operator = TargetingOperator.Equals,
+                                Value = "US",
+                                IsEnabled = true,
+                                Priority = 1
+                            }
+                        }
+                    }
+                }
+            };
+
+            var userContext = new UserContext
+            {
+                UserId = "user1",
+                Attributes = new Dictionary<string, object> { ["country"] = "US" }
+            };
+
+            // Act
+            var result = await _engine.EvaluateAsync(featureFlag, userContext);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task EvaluateAsync_FallsBackToPercentage_WhenNoRulesMatch()
+        {
+            // Arrange
+            var featureFlag = new FeatureFlag
+            {
+                Name = "test-feature",
+                IsEnabled = true,
+                Environment = "Test",
+                UseTargetingRules = true,
+                RolloutPercentage = 100, // Should fall back to this
+                TargetingRuleGroups = new List<TargetingRuleGroup>
+                {
+                    new TargetingRuleGroup
+                    {
+                        LogicalOperator = LogicalOperator.And,
+                        IsEnabled = true,
+                        Priority = 1,
+                        RolloutPercentage = 100,
+                        Rules = new List<TargetingRule>
+                        {
+                            new TargetingRule
+                            {
+                                Attribute = "country",
+                                Operator = TargetingOperator.Equals,
+                                Value = "US",
+                                IsEnabled = true,
+                                Priority = 1
+                            }
+                        }
+                    }
+                }
+            };
+
+            var userContext = new UserContext
+            {
+                UserId = "user1",
+                Attributes = new Dictionary<string, object> { ["country"] = "CA" } // Won't match rule
+            };
+
+            // Act
+            var result = await _engine.EvaluateAsync(featureFlag, userContext);
+
+            // Assert - This should be true because fallback percentage is 100%
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void EvaluateRule_ReturnsFalse_WhenRuleDisabled()
+        {
+            // Arrange
+            var rule = new TargetingRule
+            {
+                Attribute = "country",
+                Operator = TargetingOperator.Equals,
+                Value = "US",
+                IsEnabled = false // Disabled rule
+            };
+
+            var userContext = new UserContext
+            {
+                UserId = "user1",
+                Attributes = new Dictionary<string, object> { ["country"] = "US" }
+            };
+
+            // Act
+            var result = _engine.EvaluateRule(rule, userContext);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void EvaluateRule_Regex_ReturnsTrue_WhenPatternMatches()
+        {
+            // Arrange
+            var rule = new TargetingRule
+            {
+                Attribute = "email",
+                Operator = TargetingOperator.Regex,
+                Value = @".*@company\.com$",
+                IsEnabled = true
+            };
+
+            var userContext = new UserContext
+            {
+                UserId = "user1",
+                Attributes = new Dictionary<string, object> { ["email"] = "john.doe@company.com" }
+            };
+
+            // Act
+            var result = _engine.EvaluateRule(rule, userContext);
+
+            // Assert
+            Assert.True(result);
+        }
+    }
+}


### PR DESCRIPTION
- Implemented the Targeting Rules page in Razor with a form for selecting feature flags and configuring targeting rules.
- Added backend logic in TargetingRules.cshtml.cs to handle fetching and saving targeting rules.
- Created JavaScript functionality for dynamic rule group and rule management, including adding, removing, and testing rules.
- Developed unit tests for the Targeting Rules Engine to ensure correct evaluation of rules and rule groups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced advanced targeting rules for feature flags, enabling user targeting based on custom attributes (e.g., country, plan, version, beta tester status).
  * Added support for complex rule groups with logical operators (AND/OR), priority ordering, and per-group rollout percentages.
  * Enhanced dashboard with a visual rule builder, real-time testing, and analytics integration for targeting rules.
  * Provided new API endpoints, sample controllers, and UI pages to demonstrate and test targeting scenarios.

* **Documentation**
  * Expanded and updated documentation with comprehensive guides, usage examples, and quick start instructions for advanced targeting.

* **Bug Fixes**
  * Improved static file serving isolation for the dashboard.

* **Tests**
  * Added extensive unit tests for the targeting rules engine.

* **Chores**
  * Updated workflow to restrict publishing and release steps to the main branch only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->